### PR TITLE
Enforce the takedown model, and page listRepos on a keyset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,13 @@ if(METALBEAR_BUILD_TESTS)
         "${METALBEAR_CJSON_SOURCE_DIR}")
     add_test(NAME metalbear_multi_account COMMAND test_metalbear_multi_account)
 
+    add_executable(test_metalbear_takedown test/test_takedown.c)
+    target_link_libraries(test_metalbear_takedown PRIVATE metalbear_core
+        SQLite3::SQLite3)
+    target_include_directories(test_metalbear_takedown PRIVATE
+        "${METALBEAR_CJSON_SOURCE_DIR}")
+    add_test(NAME metalbear_takedown COMMAND test_metalbear_takedown)
+
     add_executable(test_metalbear_repo_store test/test_repo_store.c)
     target_link_libraries(test_metalbear_repo_store PRIVATE metalbear_core)
     target_include_directories(test_metalbear_repo_store PRIVATE

--- a/README.md
+++ b/README.md
@@ -70,9 +70,42 @@ configured admin password:
   directory, and its registry entry
 - `com.atproto.admin.updateSubjectStatus` — apply takedown, deactivation, or
   reactivation status to a repo, record, or blob subject
+- `com.atproto.admin.getSubjectStatus` — read the takedown and deactivation
+  status of a repo, record, or blob subject
 - `com.atproto.admin.updateAccountPassword` — reset an account password (admin)
 - `com.atproto.admin.enableAccountInvites` / `disableAccountInvites` — toggle
   whether an account may create invite codes
+
+## Moderation
+
+`com.atproto.admin.updateSubjectStatus` takes down an **account**, a single
+**record**, or a single **blob**, and lifts the takedown again. A blob is named
+by the DID that holds it as well as by its CID: a CID names content, so two
+accounts uploading identical bytes share one, and a takedown keyed on the CID
+alone would remove the wrong copy.
+
+```sh
+curl -sS -u "admin:$METALBEAR_ADMIN_PASSWORD" -X POST \
+  -H 'Content-Type: application/json' \
+  --data '{"subject":{"$type":"com.atproto.admin.defs#repoRef",
+                      "did":"did:plc:..."},
+           "takedown":{"applied":true,"ref":"report-123"}}' \
+  http://127.0.0.1:2583/xrpc/com.atproto.admin.updateSubjectStatus
+```
+
+Taking an account down revokes every session it holds, refuses new logins with
+`AccountTakedown`, stops its handle resolving, and announces `takendown` on the
+firehose. Its repository answers `RepoTakendown` — deliberately distinct from
+`RepoDeactivated`, since one is this host refusing to serve and the other the
+account holder's own choice, and a relay decides whether to come back on that
+difference. A taken-down record or blob reads as absent, and the blob cannot be
+re-uploaded to undo the takedown. Nothing is erased: a record stays in the
+repository, because removing it would rewrite history and break the commit
+chain, and it is withheld at the point it would be served.
+
+A takedown outranks a deactivation, so an account that is both reports
+`takendown`. Applying a takedown and a reactivation in one call is refused
+rather than resolved arbitrarily.
 
 ## OAuth Authorization Server
 
@@ -406,10 +439,6 @@ PLC directory, and its posts, profile and media appear on the Bluesky AppView.
 
 Still missing or unproven for production use:
 
-- no takedown model, so only `deactivated` and `deleted` account statuses are
-  ever reported
-- `listRepos` paginates on an integer offset rather than a keyset, so concurrent
-  account creation can skip or repeat an entry across pages
 - account deletion does not purge that DID's earlier firehose events
 - no metrics or structured operational logging
 - automatic `_atproto` record publication is implemented for Cloudflare only;

--- a/include/metalbear/account_registry.h
+++ b/include/metalbear/account_registry.h
@@ -117,20 +117,37 @@ void metalbear_invite_code_entries_free(metalbear_invite_code_entry *entries,
 
 /* --- Subject takedown status -------------------------------------------- */
 
-/* Set or clear a takedown on a subject.  Exactly one of did, uri, or
- * blob_cid must be non-NULL.  Pass ref=NULL to clear the takedown. */
+/*
+ * A takedown subject is one of three exact shapes:
+ *
+ *   account  did alone
+ *   record   uri alone
+ *   blob     did and blob_cid together
+ *
+ * A blob carries its DID because a CID names content rather than an upload:
+ * two accounts storing identical bytes share one CID, and a takedown keyed on
+ * the CID alone would remove the other account's copy. Any other combination
+ * is WF_ERR_INVALID_ARG.
+ */
+
+/* Set or clear a takedown on a subject.  Pass ref=NULL to clear it. */
 wf_status metalbear_account_registry_set_takedown(
     metalbear_account_registry *registry,
     const char *did, const char *uri, const char *blob_cid,
     const char *ref);
 
-/* Get takedown status for a subject.  Exactly one of did, uri, or
- * blob_cid must be non-NULL.  On WF_OK *out_ref is either NULL (no
+/* Get takedown status for a subject.  On WF_OK *out_ref is either NULL (no
  * takedown) or a heap-allocated ref string; caller frees it. */
 wf_status metalbear_account_registry_get_takedown(
     metalbear_account_registry *registry,
     const char *did, const char *uri, const char *blob_cid,
     char **out_ref);
+
+/* Drop every takedown belonging to an account — the account itself, its
+ * records, and its blobs.  Called when the account is deleted, so a DID that
+ * is later re-registered does not inherit the old one's moderation state. */
+wf_status metalbear_account_registry_clear_takedowns_for_did(
+    metalbear_account_registry *registry, const char *did);
 
 #ifdef __cplusplus
 }

--- a/include/metalbear/account_registry.h
+++ b/include/metalbear/account_registry.h
@@ -50,9 +50,25 @@ wf_status metalbear_account_registry_find_by_did(
     metalbear_account_registry *registry,
     const char *did, metalbear_account_entry **out);
 
-/* List all accounts. Caller must free the array and each entry. */
+/* List all accounts, ordered by handle. Caller must free the array and each
+ * entry. For anything a client pages through, use the keyset walk below. */
 wf_status metalbear_account_registry_list(
     metalbear_account_registry *registry,
+    metalbear_account_entry **out_entries, size_t *out_count);
+
+/*
+ * One page of accounts with a DID strictly greater than `after` (NULL or ""
+ * for the first page), ordered by DID, at most `limit` of them. A page that
+ * comes back short is the last one.
+ *
+ * Paged on the DID rather than on a row offset because accounts are created
+ * and deleted while a client walks the list, and an offset counts positions
+ * in a list that has since shifted — the account that moved into the slot
+ * already read is never returned, and the one that moved out is returned
+ * twice. The DID is the only key here that a later operation cannot change.
+ */
+wf_status metalbear_account_registry_list_after(
+    metalbear_account_registry *registry, const char *after, size_t limit,
     metalbear_account_entry **out_entries, size_t *out_count);
 
 void metalbear_account_entry_free(metalbear_account_entry *entry);

--- a/include/metalbear/repo_store.h
+++ b/include/metalbear/repo_store.h
@@ -35,6 +35,7 @@
 #define METALBEAR_REPO_STORE_H
 
 #include <cJSON.h>
+#include <stdbool.h>
 
 #include "wolfram/validate.h"
 #include "wolfram/xrpc.h"
@@ -453,13 +454,30 @@ wf_status metalbear_xrpc_server_register_pds_repo_resolver(
  */
 typedef char *(*metalbear_xrpc_did_doc_provider)(void *ctx, const char *did);
 
+/*
+ * Consulted before a repository read is served, so moderation state that the
+ * repository itself does not carry can refuse the request. `record_uri` names
+ * the single record being read, or is NULL when the request is about the
+ * repository as a whole. Return false with `resp` already filled in to refuse;
+ * the handler then returns without touching the store.
+ *
+ * The guard, not the store, is where a takedown lives: a taken-down record
+ * stays in the repository — removing it would rewrite history and break the
+ * commit chain — and is withheld at the point it would be served.
+ */
+typedef bool (*metalbear_xrpc_repo_access_guard)(void *ctx,
+                                                 const wf_xrpc_request *req,
+                                                 const char *record_uri,
+                                                 wf_xrpc_response *resp);
+
 /**
  * As metalbear_xrpc_server_register_pds_repo_resolver, additionally wiring an
  * identity-layer DID document provider and a lexicon registry. Without a
  * provider, describeRepo falls back to a locally derived document and reports
  * handleIsCorrect=false, since the PDS cannot confirm the handle resolves back
  * to the DID on its own. Without a registry, every write reports
- * validationStatus "unknown", since nothing can be checked.
+ * validationStatus "unknown", since nothing can be checked. Without a guard,
+ * every record the store holds is served.
  *
  * The registry is borrowed and must outlive the server.
  */
@@ -467,7 +485,8 @@ wf_status metalbear_xrpc_server_register_pds_repo_resolver_ex(
     wf_xrpc_server *server, metalbear_xrpc_repo_resolver resolver, void *ctx,
     const char *service_did, const char *public_url,
     metalbear_xrpc_did_doc_provider did_doc_provider, void *did_doc_ctx,
-    const wf_lexicon_registry *lexicons);
+    const wf_lexicon_registry *lexicons,
+    metalbear_xrpc_repo_access_guard guard, void *guard_ctx);
 
 /** Outcome of checking a record against the lexicon corpus. */
 typedef enum metalbear_validation_status {

--- a/src/account_registry.c
+++ b/src/account_registry.c
@@ -502,12 +502,29 @@ wf_status metalbear_account_registry_disable_invite_codes(
     return touched > 0 ? WF_OK : WF_ERR_NOT_FOUND;
 }
 
-static int count_nonnull(const char *a, const char *b, const char *c) {
-    int n = 0;
-    if (a && a[0]) n++;
-    if (b && b[0]) n++;
-    if (c && c[0]) n++;
-    return n;
+/*
+ * A takedown subject is one of three exact shapes: an account (did alone), a
+ * record (uri alone), or a blob (did *and* cid together). The blob shape is
+ * why the row cannot be keyed on a single populated column: a CID identifies
+ * content, not an upload, so the same bytes stored by two accounts are one CID,
+ * and a takedown keyed on the CID alone would remove another account's copy.
+ */
+static bool takedown_subject_valid(const char *did, const char *uri,
+                                   const char *blob_cid) {
+    bool has_did = did && did[0];
+    bool has_uri = uri && uri[0];
+    bool has_cid = blob_cid && blob_cid[0];
+    if (has_uri) return !has_did && !has_cid;
+    if (has_cid) return has_did;
+    return has_did;
+}
+
+/* Bind an empty-or-NULL string as SQL NULL, so `IS ?` matches the stored row. */
+static void bind_text_or_null(sqlite3_stmt *stmt, int index, const char *value) {
+    if (value && value[0])
+        sqlite3_bind_text(stmt, index, value, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, index);
 }
 
 wf_status metalbear_account_registry_set_takedown(
@@ -515,23 +532,23 @@ wf_status metalbear_account_registry_set_takedown(
     const char *did, const char *uri, const char *blob_cid,
     const char *ref) {
     if (!registry) return WF_ERR_INVALID_ARG;
-    if (count_nonnull(did, uri, blob_cid) != 1)
+    if (!takedown_subject_valid(did, uri, blob_cid))
         return WF_ERR_INVALID_ARG;
     pthread_mutex_lock(&registry->mutex);
-    /* Remove any existing takedown for this subject. */
+    /*
+     * Match the subject on all three columns at once. Matching whichever
+     * column was populated meant an account's blob takedown also carried
+     * `did`, so a lookup for the account itself found the blob's row and
+     * reported the whole repository taken down.
+     */
     sqlite3_stmt *del = NULL;
     if (sqlite3_prepare_v2(registry->db,
             "DELETE FROM subject_takedown WHERE "
-            "((did IS ? AND ? IS NOT NULL) OR "
-            " (uri IS ? AND ? IS NOT NULL) OR "
-            " (blob_cid IS ? AND ? IS NOT NULL));",
+            "did IS ? AND uri IS ? AND blob_cid IS ?;",
             -1, &del, NULL) == SQLITE_OK) {
-        sqlite3_bind_text(del, 1, did, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(del, 2, did, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(del, 3, uri, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(del, 4, uri, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(del, 5, blob_cid, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(del, 6, blob_cid, -1, SQLITE_TRANSIENT);
+        bind_text_or_null(del, 1, did);
+        bind_text_or_null(del, 2, uri);
+        bind_text_or_null(del, 3, blob_cid);
         sqlite3_step(del);
     }
     sqlite3_finalize(del);
@@ -542,9 +559,9 @@ wf_status metalbear_account_registry_set_takedown(
                 "INSERT INTO subject_takedown(did,uri,blob_cid,"
                 "takedown_ref,created_at) VALUES(?,?,?,?,datetime('now'));",
                 -1, &ins, NULL) == SQLITE_OK) {
-            sqlite3_bind_text(ins, 1, did, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_text(ins, 2, uri, -1, SQLITE_TRANSIENT);
-            sqlite3_bind_text(ins, 3, blob_cid, -1, SQLITE_TRANSIENT);
+            bind_text_or_null(ins, 1, did);
+            bind_text_or_null(ins, 2, uri);
+            bind_text_or_null(ins, 3, blob_cid);
             sqlite3_bind_text(ins, 4, ref, -1, SQLITE_TRANSIENT);
             sqlite3_step(ins);
         }
@@ -560,23 +577,18 @@ wf_status metalbear_account_registry_get_takedown(
     char **out_ref) {
     if (!registry || !out_ref) return WF_ERR_INVALID_ARG;
     *out_ref = NULL;
-    if (count_nonnull(did, uri, blob_cid) != 1)
+    if (!takedown_subject_valid(did, uri, blob_cid))
         return WF_ERR_INVALID_ARG;
     pthread_mutex_lock(&registry->mutex);
     sqlite3_stmt *sel = NULL;
     wf_status status = WF_OK;
     if (sqlite3_prepare_v2(registry->db,
             "SELECT takedown_ref FROM subject_takedown WHERE "
-            "(did IS ? AND ? IS NOT NULL) OR "
-            "(uri IS ? AND ? IS NOT NULL) OR "
-            "(blob_cid IS ? AND ? IS NOT NULL) LIMIT 1;",
+            "did IS ? AND uri IS ? AND blob_cid IS ? LIMIT 1;",
             -1, &sel, NULL) == SQLITE_OK) {
-        sqlite3_bind_text(sel, 1, did, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(sel, 2, did, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(sel, 3, uri, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(sel, 4, uri, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(sel, 5, blob_cid, -1, SQLITE_TRANSIENT);
-        sqlite3_bind_text(sel, 6, blob_cid, -1, SQLITE_TRANSIENT);
+        bind_text_or_null(sel, 1, did);
+        bind_text_or_null(sel, 2, uri);
+        bind_text_or_null(sel, 3, blob_cid);
         if (sqlite3_step(sel) == SQLITE_ROW) {
             const char *ref = (const char *)sqlite3_column_text(sel, 0);
             *out_ref = ref ? strdup(ref) : NULL;
@@ -585,6 +597,36 @@ wf_status metalbear_account_registry_get_takedown(
         status = WF_ERR_INTERNAL;
     }
     sqlite3_finalize(sel);
+    pthread_mutex_unlock(&registry->mutex);
+    return status;
+}
+
+wf_status metalbear_account_registry_clear_takedowns_for_did(
+    metalbear_account_registry *registry, const char *did) {
+    if (!registry || !did || !did[0]) return WF_ERR_INVALID_ARG;
+    pthread_mutex_lock(&registry->mutex);
+    /*
+     * Records are keyed by their at-URI, whose authority is the DID, so they
+     * are matched by prefix rather than by column. Compared with substr rather
+     * than LIKE because a `did:web` may percent-encode a port, and `%` is
+     * LIKE's own wildcard.
+     */
+    sqlite3_stmt *del = NULL;
+    wf_status status = WF_OK;
+    if (sqlite3_prepare_v2(registry->db,
+            "DELETE FROM subject_takedown WHERE did IS ? "
+            "OR substr(uri, 1, ?) = ?;",
+            -1, &del, NULL) == SQLITE_OK) {
+        char prefix[512];
+        int len = snprintf(prefix, sizeof(prefix), "at://%s/", did);
+        sqlite3_bind_text(del, 1, did, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(del, 2, len);
+        sqlite3_bind_text(del, 3, prefix, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(del) != SQLITE_DONE) status = WF_ERR_INTERNAL;
+    } else {
+        status = WF_ERR_INTERNAL;
+    }
+    sqlite3_finalize(del);
     pthread_mutex_unlock(&registry->mutex);
     return status;
 }

--- a/src/account_registry.c
+++ b/src/account_registry.c
@@ -261,6 +261,56 @@ wf_status metalbear_account_registry_list(
     return status;
 }
 
+wf_status metalbear_account_registry_list_after(
+    metalbear_account_registry *registry, const char *after, size_t limit,
+    metalbear_account_entry **out_entries, size_t *out_count) {
+    if (!registry || !out_entries || !out_count || limit == 0)
+        return WF_ERR_INVALID_ARG;
+    *out_entries = NULL;
+    *out_count = 0;
+    pthread_mutex_lock(&registry->mutex);
+    sqlite3_stmt *stmt = NULL;
+    wf_status status = WF_OK;
+    size_t capacity = 0;
+    /*
+     * Ordered and resumed by DID, not by handle: a handle can be changed, and
+     * a page boundary that moves under a client walking the list makes it
+     * skip or repeat accounts. A DID never changes once minted.
+     */
+    if (sqlite3_prepare_v2(registry->db,
+            "SELECT did,handle,password_hash,data_directory,active "
+            "FROM accounts WHERE did > ? ORDER BY did LIMIT ?;",
+            -1, &stmt, NULL) != SQLITE_OK) {
+        status = WF_ERR_INTERNAL;
+    } else {
+        sqlite3_bind_text(stmt, 1, after ? after : "", -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(stmt, 2, (sqlite3_int64)limit);
+    }
+    while (status == WF_OK && sqlite3_step(stmt) == SQLITE_ROW) {
+        if (*out_count == capacity) {
+            size_t next = capacity ? capacity * 2 : 4;
+            void *resized = realloc(*out_entries,
+                                    next * sizeof(**out_entries));
+            if (!resized) { status = WF_ERR_ALLOC; break; }
+            *out_entries = resized;
+            memset(*out_entries + capacity, 0,
+                   (next - capacity) * sizeof(**out_entries));
+            capacity = next;
+        }
+        metalbear_account_entry *item = &(*out_entries)[*out_count];
+        status = read_entry(stmt, item);
+        if (status == WF_OK) (*out_count)++;
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(&registry->mutex);
+    if (status != WF_OK) {
+        metalbear_account_entries_free(*out_entries, *out_count);
+        *out_entries = NULL;
+        *out_count = 0;
+    }
+    return status;
+}
+
 wf_status metalbear_account_registry_remove(
     metalbear_account_registry *registry,
     const char *did) {

--- a/src/repo_store.c
+++ b/src/repo_store.c
@@ -1593,7 +1593,19 @@ typedef struct metalbear_pds_repo_bundle {
     metalbear_xrpc_did_doc_provider did_doc_provider;
     void *did_doc_ctx;
     const wf_lexicon_registry *lexicons; /* borrowed */
+    metalbear_xrpc_repo_access_guard guard;
+    void *guard_ctx;
 } metalbear_pds_repo_bundle;
+
+/* Run the access guard, if one is installed. False means the guard has
+ * already written the refusal into `resp`. */
+static bool repo_access_allowed(metalbear_pds_repo_bundle *b,
+                                const wf_xrpc_request *req,
+                                const char *record_uri,
+                                wf_xrpc_response *resp) {
+    if (!b->guard) return true;
+    return b->guard(b->guard_ctx, req, record_uri, resp);
+}
 
 /*
  * Resolve the repo store for a request from the registration's bundle.
@@ -1616,6 +1628,7 @@ static metalbear_repo_store *resolve_repo(metalbear_pds_repo_bundle *b,
         }
         store = out_repo;
     }
+    if (!repo_access_allowed(b, req, NULL, resp)) return NULL;
     return store;
 }
 
@@ -1956,6 +1969,14 @@ static wf_status h_get_record(void *ctx, const wf_xrpc_request *req,
                                    "collection and rkey required");
         return WF_OK;
     }
+    /* A taken-down record reads as absent. It is still in the repository —
+     * removing it would rewrite history — so the guard is what withholds it. */
+    char *guard_uri = make_uri(s->did, collection->valuestring,
+                               rkey->valuestring);
+    bool allowed = repo_access_allowed((metalbear_pds_repo_bundle *)ctx, req,
+                                       guard_uri, resp);
+    free(guard_uri);
+    if (!allowed) return WF_OK;
     char *rec = NULL, *cid = NULL;
     wf_status st = metalbear_repo_store_get_record(s, collection->valuestring,
                                             rkey->valuestring, &rec, &cid);
@@ -2924,14 +2945,16 @@ wf_status metalbear_xrpc_server_register_pds_repo_resolver(
     wf_xrpc_server *server, metalbear_xrpc_repo_resolver resolver, void *ctx,
     const char *service_did, const char *public_url) {
     return metalbear_xrpc_server_register_pds_repo_resolver_ex(
-        server, resolver, ctx, service_did, public_url, NULL, NULL, NULL);
+        server, resolver, ctx, service_did, public_url, NULL, NULL, NULL,
+        NULL, NULL);
 }
 
 wf_status metalbear_xrpc_server_register_pds_repo_resolver_ex(
     wf_xrpc_server *server, metalbear_xrpc_repo_resolver resolver, void *ctx,
     const char *service_did, const char *public_url,
     metalbear_xrpc_did_doc_provider did_doc_provider, void *did_doc_ctx,
-    const wf_lexicon_registry *lexicons) {
+    const wf_lexicon_registry *lexicons,
+    metalbear_xrpc_repo_access_guard guard, void *guard_ctx) {
     if (!server) return WF_ERR_INVALID_ARG;
     metalbear_pds_repo_bundle *b = (metalbear_pds_repo_bundle *)malloc(sizeof(*b));
     if (!b) return WF_ERR_ALLOC;
@@ -2941,6 +2964,8 @@ wf_status metalbear_xrpc_server_register_pds_repo_resolver_ex(
     b->did_doc_provider = did_doc_provider;
     b->did_doc_ctx = did_doc_ctx;
     b->lexicons = lexicons;
+    b->guard = guard;
+    b->guard_ctx = guard_ctx;
     if (service_did) b->service_did = strdup(service_did);
     if (public_url) b->public_url = strdup(public_url);
     wf_xrpc_server_own_ctx(server, b, free);

--- a/src/server.c
+++ b/src/server.c
@@ -5903,14 +5903,10 @@ static wf_status list_repos_by_collection(void *ctx,
         return WF_OK;
     }
     int limit = query_param_int(request->params, "limit", 500, 1, 2000);
-    size_t offset = 0;
     const cJSON *cursor_param = request->params
         ? cJSON_GetObjectItemCaseSensitive(request->params, "cursor") : NULL;
-    if (cJSON_IsString(cursor_param) && cursor_param->valuestring[0]) {
-        char *end = NULL;
-        long parsed = strtol(cursor_param->valuestring, &end, 10);
-        if (*end == '\0' && parsed >= 0) offset = (size_t)parsed;
-    }
+    const char *cursor = cJSON_IsString(cursor_param)
+        ? cursor_param->valuestring : "";
 
     cJSON *root = cJSON_CreateObject();
     cJSON *repos = cJSON_CreateArray();
@@ -5920,62 +5916,66 @@ static wf_status list_repos_by_collection(void *ctx,
         return WF_ERR_ALLOC;
     }
 
-    metalbear_account_entry *entries = NULL;
-    size_t count = 0;
-    if (metalbear_account_registry_list(server->registry, &entries,
-                                        &count) != WF_OK) {
-        entries = NULL;
-        count = 0;
-    }
-    if (offset > count) offset = count;
-
     /* As in listRepos, `limit` counts accounts returned rather than rows
-     * examined, so accounts without the collection never occupy a slot. */
+     * examined, so accounts without the collection never occupy a slot, and
+     * the registry is walked a page at a time until the page is full. */
+    char last_did[256] = "";
+    snprintf(last_did, sizeof(last_did), "%s", cursor);
+    bool exhausted = false;
     size_t emitted = 0;
-    size_t scanned = offset;
-    for (size_t i = offset; i < count && emitted < (size_t)limit;
-         i++, scanned = i) {
-        metalbear_account_context *acct = context_for_did(server,
-                                                          entries[i].did);
-        if (!acct) continue;
-        char *described = NULL;
-        if (metalbear_repo_store_describe(acct->repo, &described) != WF_OK ||
-            !described)
-            continue;
-        cJSON *desc = cJSON_Parse(described);
-        free(described);
-        if (!desc) continue;
-        bool holds = false;
-        const cJSON *cols = cJSON_GetObjectItemCaseSensitive(desc,
-                                                             "collections");
-        const cJSON *item = NULL;
-        cJSON_ArrayForEach(item, cols) {
-            if (cJSON_IsString(item) &&
-                strcmp(item->valuestring, coll->valuestring) == 0) {
-                holds = true;
+    wf_status alloc_failure = WF_OK;
+    while (emitted < (size_t)limit && !exhausted && alloc_failure == WF_OK) {
+        metalbear_account_entry *entries = NULL;
+        size_t count = 0;
+        if (metalbear_account_registry_list_after(
+                server->registry, last_did, (size_t)limit, &entries,
+                &count) != WF_OK)
+            break;
+        if (count < (size_t)limit) exhausted = true;
+        for (size_t i = 0; i < count && emitted < (size_t)limit; i++) {
+            snprintf(last_did, sizeof(last_did), "%s", entries[i].did);
+            metalbear_account_context *acct = context_for_did(server,
+                                                              entries[i].did);
+            if (!acct) continue;
+            char *described = NULL;
+            if (metalbear_repo_store_describe(acct->repo, &described) != WF_OK ||
+                !described)
+                continue;
+            cJSON *desc = cJSON_Parse(described);
+            free(described);
+            if (!desc) continue;
+            bool holds = false;
+            const cJSON *cols = cJSON_GetObjectItemCaseSensitive(desc,
+                                                                 "collections");
+            const cJSON *item = NULL;
+            cJSON_ArrayForEach(item, cols) {
+                if (cJSON_IsString(item) &&
+                    strcmp(item->valuestring, coll->valuestring) == 0) {
+                    holds = true;
+                    break;
+                }
+            }
+            cJSON_Delete(desc);
+            if (!holds) continue;
+            cJSON *repo = cJSON_CreateObject();
+            if (!repo) {
+                alloc_failure = WF_ERR_ALLOC;
                 break;
             }
+            cJSON_AddStringToObject(repo, "did", acct->did);
+            cJSON_AddItemToArray(repos, repo);
+            emitted++;
         }
-        cJSON_Delete(desc);
-        if (!holds) continue;
-        cJSON *repo = cJSON_CreateObject();
-        if (!repo) {
-            metalbear_account_entries_free(entries, count);
-            cJSON_Delete(root);
-            cJSON_Delete(repos);
-            return WF_ERR_ALLOC;
-        }
-        cJSON_AddStringToObject(repo, "did", acct->did);
-        cJSON_AddItemToArray(repos, repo);
-        emitted++;
+        metalbear_account_entries_free(entries, count);
     }
-    metalbear_account_entries_free(entries, count);
+    if (alloc_failure != WF_OK) {
+        cJSON_Delete(root);
+        cJSON_Delete(repos);
+        return alloc_failure;
+    }
     cJSON_AddItemToObject(root, "repos", repos);
-    if (scanned < count) {
-        char cursor_buf[32];
-        snprintf(cursor_buf, sizeof(cursor_buf), "%zu", scanned);
-        cJSON_AddStringToObject(root, "cursor", cursor_buf);
-    }
+    if (!exhausted && last_did[0])
+        cJSON_AddStringToObject(root, "cursor", last_did);
     return set_json(response, root);
 }
 
@@ -5986,13 +5986,8 @@ static wf_status list_repos(void *ctx, const wf_xrpc_request *request,
     int limit = query_param_int(request->params, "limit", 500, 1, 1000);
     cJSON *cursor_param = request->params
         ? cJSON_GetObjectItemCaseSensitive(request->params, "cursor") : NULL;
-    size_t offset = 0;
-    if (cJSON_IsString(cursor_param) && cursor_param->valuestring[0]) {
-        char *end = NULL;
-        long parsed = strtol(cursor_param->valuestring, &end, 10);
-        if (*cursor_param->valuestring && *end == '\0' && parsed >= 0)
-            offset = (size_t)parsed;
-    }
+    const char *cursor = cJSON_IsString(cursor_param)
+        ? cursor_param->valuestring : "";
 
     cJSON *root = cJSON_CreateObject();
     cJSON *repos = cJSON_CreateArray();
@@ -6001,14 +5996,7 @@ static wf_status list_repos(void *ctx, const wf_xrpc_request *request,
         cJSON_Delete(repos);
         return WF_ERR_ALLOC;
     }
-    metalbear_account_entry *entries = NULL;
-    size_t count = 0;
-    if (metalbear_account_registry_list(server->registry, &entries,
-                                        &count) != WF_OK) {
-        entries = NULL;
-        count = 0;
-    }
-    if (offset > count) offset = count;
+
     /*
      * `limit` counts repos returned, not registry rows examined.
      *
@@ -6018,51 +6006,73 @@ static wf_status list_repos(void *ctx, const wf_xrpc_request *request,
      * relay enumerating accounts sees no accounts and concludes the host hosts
      * nothing. The reference joins against the repo root, so entries without a
      * repository never occupy a slot at all.
+     *
+     * Skipped rows are why the registry is walked a page at a time rather
+     * than asked for `limit` rows once: a batch of entries can yield fewer
+     * repositories than it holds, and the walk continues until the page is
+     * full or the registry is exhausted.
      */
+    char last_did[256] = "";
+    snprintf(last_did, sizeof(last_did), "%s", cursor);
+    bool exhausted = false;
     size_t emitted = 0;
-    size_t scanned = offset;
-    for (size_t i = offset; i < count && emitted < (size_t)limit;
-         i++, scanned = i) {
-        metalbear_account_context *acct = context_for_did(server,
-                                                          entries[i].did);
-        if (!acct) continue;
-        char *rev = NULL, *cid = NULL;
-        if (metalbear_repo_store_get_head(acct->repo, &rev, &cid) != WF_OK) {
+    wf_status alloc_failure = WF_OK;
+    while (emitted < (size_t)limit && !exhausted && alloc_failure == WF_OK) {
+        metalbear_account_entry *entries = NULL;
+        size_t count = 0;
+        if (metalbear_account_registry_list_after(
+                server->registry, last_did, (size_t)limit, &entries,
+                &count) != WF_OK)
+            break;
+        if (count < (size_t)limit) exhausted = true;
+        for (size_t i = 0; i < count && emitted < (size_t)limit; i++) {
+            snprintf(last_did, sizeof(last_did), "%s", entries[i].did);
+            metalbear_account_context *acct = context_for_did(server,
+                                                              entries[i].did);
+            if (!acct) continue;
+            char *rev = NULL, *cid = NULL;
+            if (metalbear_repo_store_get_head(acct->repo, &rev, &cid) != WF_OK) {
+                free(rev);
+                free(cid);
+                continue;
+            }
+            cJSON *repo = cJSON_CreateObject();
+            if (!repo) {
+                free(rev);
+                free(cid);
+                alloc_failure = WF_ERR_ALLOC;
+                break;
+            }
+            cJSON_AddStringToObject(repo, "did", acct->did);
+            cJSON_AddStringToObject(repo, "head", cid);
+            cJSON_AddStringToObject(repo, "rev", rev);
+            bool active = false;
+            const char *status = account_status_string(server, acct, &active);
+            cJSON_AddBoolToObject(repo, "active", active);
+            if (status)
+                cJSON_AddStringToObject(repo, "status", status);
+            cJSON_AddItemToArray(repos, repo);
+            emitted++;
             free(rev);
             free(cid);
-            continue;
         }
-        cJSON *repo = cJSON_CreateObject();
-        if (!repo) {
-            free(rev);
-            free(cid);
-            metalbear_account_entries_free(entries, count);
-            cJSON_Delete(root);
-            cJSON_Delete(repos);
-            return WF_ERR_ALLOC;
-        }
-        cJSON_AddStringToObject(repo, "did", acct->did);
-        cJSON_AddStringToObject(repo, "head", cid);
-        cJSON_AddStringToObject(repo, "rev", rev);
-        bool active = false;
-        const char *status = account_status_string(server, acct, &active);
-        cJSON_AddBoolToObject(repo, "active", active);
-        if (status)
-            cJSON_AddStringToObject(repo, "status", status);
-        cJSON_AddItemToArray(repos, repo);
-        emitted++;
-        free(rev);
-        free(cid);
+        metalbear_account_entries_free(entries, count);
     }
-    metalbear_account_entries_free(entries, count);
+    if (alloc_failure != WF_OK) {
+        cJSON_Delete(root);
+        cJSON_Delete(repos);
+        return alloc_failure;
+    }
     cJSON_AddItemToObject(root, "repos", repos);
-    /* Resume where the scan stopped, so skipped rows are not revisited. */
-    size_t next = scanned;
-    if (next < count) {
-        char cursor_buf[32];
-        snprintf(cursor_buf, sizeof(cursor_buf), "%zu", next);
-        cJSON_AddStringToObject(root, "cursor", cursor_buf);
-    }
+    /*
+     * The cursor is the last DID read, so the next page resumes after it
+     * whatever has been created or deleted in between. It is omitted only
+     * when the registry is known to be exhausted — a full page that happens
+     * to end at the last account still hands out a cursor, and the client
+     * gets one empty page rather than a truncated enumeration.
+     */
+    if (!exhausted && last_did[0])
+        cJSON_AddStringToObject(root, "cursor", last_did);
     return set_json(response, root);
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -361,6 +361,43 @@ static const char *request_account_did(metalbear_server *server,
     return NULL;
 }
 
+/*
+ * Split `at://<authority>/<collection>/<rkey>` into its three parts, each
+ * copied into the caller's buffer. Returns false unless all three are present
+ * and fit: a strong reference names exactly one record, and a URI stopping at
+ * the collection names a great many.
+ */
+static bool split_at_uri(const char *uri,
+                         char *authority, size_t authority_sz,
+                         char *collection, size_t collection_sz,
+                         char *rkey, size_t rkey_sz) {
+    if (!uri || strncmp(uri, "at://", 5) != 0) return false;
+    const char *parts[3];
+    size_t lengths[3];
+    const char *p = uri + 5;
+    for (int i = 0; i < 3; i++) {
+        parts[i] = p;
+        size_t n = 0;
+        while (p[n] && p[n] != '/') n++;
+        lengths[i] = n;
+        if (n == 0) return false;
+        p += n;
+        if (i < 2) {
+            if (*p != '/') return false;
+            p++;
+        }
+    }
+    if (*p != '\0') return false;
+    char *outs[3] = { authority, collection, rkey };
+    size_t sizes[3] = { authority_sz, collection_sz, rkey_sz };
+    for (int i = 0; i < 3; i++) {
+        if (lengths[i] >= sizes[i]) return false;
+        memcpy(outs[i], parts[i], lengths[i]);
+        outs[i][lengths[i]] = '\0';
+    }
+    return true;
+}
+
 /* Return the cached context for `did`. The returned context is owned by the
  * cache and must NOT be freed by the caller. Returns NULL when the DID is
  * unknown / cannot be opened. Every account resolves the same way — there is
@@ -429,6 +466,9 @@ static bool full_access_route(const char *nsid) {
            strcmp(nsid, "com.atproto.server.deactivateAccount") == 0;
 }
 
+/* Defined below alongside the other account-status helpers. */
+static bool account_is_taken_down(metalbear_server *server, const char *did);
+
 static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
     metalbear_server *server = ctx;
     LOG_DEBUG("authenticate: nsid=%s method=%s host=%s auth=%s",
@@ -443,17 +483,20 @@ static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
         return admin_authenticated(server, req) ? WF_OK : WF_ERR_PERMISSION;
     if (is_public_route(req->nsid)) {
         /*
-         * A deactivated account's repo is not readable. Resolve which account
+         * An unavailable account's repo is not readable. Resolve which account
          * the request names rather than consulting a single privileged one:
          * checking the configured account's state meant one user deactivating
          * took every other account's public reads down with them, and left a
          * deactivated user's own repo readable.
+         *
+         * Only the `com.atproto.repo` reads are gated here, and only for
+         * deactivation. Everything else — takedowns, and the sync reads —
+         * goes through assert_repo_available in the handlers, because this
+         * gate can report `RepoDeactivated` and nothing else: a takedown
+         * answered under that name tells a consuming relay the account holder
+         * chose to leave, when this host in fact refused to serve them.
          */
-        if (strncmp(req->nsid, "com.atproto.repo.", 17) == 0 ||
-            strcmp(req->nsid, "com.atproto.sync.getLatestCommit") == 0 ||
-            strcmp(req->nsid, "com.atproto.sync.getBlob") == 0 ||
-            strcmp(req->nsid, "com.atproto.sync.getRepo") == 0 ||
-            strcmp(req->nsid, "com.atproto.sync.getBlocks") == 0) {
+        if (strncmp(req->nsid, "com.atproto.repo.", 17) == 0) {
             const cJSON *repo = req->params
                 ? cJSON_GetObjectItemCaseSensitive(req->params, "repo") : NULL;
             const cJSON *did = req->params
@@ -463,7 +506,8 @@ static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
             if (target) {
                 metalbear_account_context *acct =
                     context_for_identifier(server, target->valuestring);
-                if (acct && !metalbear_account_is_active(acct->account))
+                if (acct && !metalbear_account_is_active(acct->account) &&
+                    !account_is_taken_down(server, acct->did))
                     return WF_ERR_CONFLICT;
             }
         }
@@ -531,6 +575,23 @@ static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
         scope != METALBEAR_ACCESS_FULL) {
         LOG_WARN("authenticate: insufficient scope for did=%s nsid=%s scope=%d",
                  sub, req->nsid ? req->nsid : "-", scope);
+        free(sub);
+        return WF_ERR_PERMISSION;
+    }
+    /*
+     * A takedown admits none of the exceptions a deactivation does: the
+     * routes a deactivated account may still reach exist so its holder can
+     * reactivate or export, and a taken-down account reactivating itself
+     * would undo the moderation action. Sessions are revoked when the
+     * takedown is applied, but a token minted before it must not outlive it.
+     *
+     * The refresh pair is left to its handlers, which answer with the
+     * lexicon's `AccountTakedown` rather than a bare authentication failure —
+     * the difference a client needs to stop retrying and tell its user why.
+     */
+    if (!refresh_route && account_is_taken_down(server, sub)) {
+        LOG_WARN("authenticate: taken-down account did=%s nsid=%s", sub,
+                 req->nsid ? req->nsid : "-");
         free(sub);
         return WF_ERR_PERMISSION;
     }
@@ -672,8 +733,11 @@ static wf_status delete_account(void *ctx, const wf_xrpc_request *request,
     metalbear_account_delete(acct->account);
     /* Deactivate the account */
     metalbear_account_deactivate(acct->account, NULL);
-    /* Remove from the account registry */
+    /* Remove from the account registry, moderation state included: a DID
+     * re-registered later must not inherit the old account's takedowns. */
     metalbear_account_registry_remove(server->registry, acct->did);
+    metalbear_account_registry_clear_takedowns_for_did(server->registry,
+                                                       acct->did);
     /* Emit deactivation event to firehose */
     metalbear_sequencer_account_status(acct->sequencer, acct->did, 0,
                                        "deleted");
@@ -781,7 +845,8 @@ static wf_status resolve_handle(void *ctx, const wf_xrpc_request *request,
     metalbear_account_context *acct = cJSON_IsString(handle) &&
         wf_syntax_handle_is_valid(handle->valuestring)
         ? context_for_identifier(server, handle->valuestring) : NULL;
-    if (!acct || !metalbear_account_is_active(acct->account)) {
+    if (!acct || !metalbear_account_is_active(acct->account) ||
+        account_is_taken_down(server, acct->did)) {
         wf_xrpc_response_set_error(response, 400, "HandleNotFound",
                                    "Unable to resolve handle");
         return WF_OK;
@@ -1013,13 +1078,14 @@ static bool did_doc_matches_service(metalbear_server *server,
 
 /* Build (local) or fetch (remote) the DID document for `did` as a cJSON
  * tree. Caller must cJSON_Delete the result. Sets *deactivated when the
- * local account exists but is deactivated. */
+ * local account exists but is unavailable — deactivated or taken down. */
 static cJSON *did_doc_for_did(metalbear_server *server, const char *did,
                               bool *deactivated) {
     *deactivated = false;
     metalbear_account_context *acct = context_for_did(server, did);
     if (acct) {
-        if (!metalbear_account_is_active(acct->account)) {
+        if (!metalbear_account_is_active(acct->account) ||
+            account_is_taken_down(server, acct->did)) {
             *deactivated = true;
             return NULL;
         }
@@ -1599,6 +1665,120 @@ static metalbear_credential_kind valid_login(
     return credential;
 }
 
+/*
+ * `com.atproto.admin.defs#statusAttr` — `applied` is required, so a status
+ * that is not applied is reported as `applied: false` rather than by omitting
+ * the field. A moderator reading an omitted key cannot tell "not taken down"
+ * from "this server does not track takedowns".
+ */
+static cJSON *status_attr(bool applied, const char *ref) {
+    cJSON *attr = cJSON_CreateObject();
+    if (!attr) return NULL;
+    cJSON_AddBoolToObject(attr, "applied", applied);
+    if (applied && ref && ref[0])
+        cJSON_AddStringToObject(attr, "ref", ref);
+    return attr;
+}
+
+/* The takedown ref recorded against an account, or NULL. Caller frees. */
+static char *account_takedown_ref(metalbear_server *server, const char *did) {
+    char *ref = NULL;
+    if (!did || !did[0]) return NULL;
+    metalbear_account_registry_get_takedown(server->registry, did, NULL, NULL,
+                                            &ref);
+    return ref;
+}
+
+/*
+ * The account status the lexicons report, mirroring the reference PDS's
+ * formatAccountStatus: a takedown outranks a deactivation, and an active
+ * account carries no `status` at all. Returns NULL when active, and writes
+ * the accompanying `active` boolean through `out_active`.
+ */
+static const char *account_status_string(metalbear_server *server,
+                                         metalbear_account_context *acct,
+                                         bool *out_active) {
+    char *ref = account_takedown_ref(server, acct->did);
+    bool taken_down = ref != NULL;
+    free(ref);
+    bool active = !taken_down && metalbear_account_is_active(acct->account);
+    if (out_active) *out_active = active;
+    if (taken_down) return "takendown";
+    return active ? NULL : "deactivated";
+}
+
+/* Whether the account is taken down, which no bearer token may act through. */
+static bool account_is_taken_down(metalbear_server *server, const char *did) {
+    char *ref = account_takedown_ref(server, did);
+    bool taken_down = ref != NULL;
+    free(ref);
+    return taken_down;
+}
+
+/*
+ * The reference PDS's assertRepoAvailability, which every sync read runs
+ * before touching the repository. A taken-down repository reports a different
+ * error from a deactivated one because the two mean opposite things to a
+ * consumer: one is a moderation action by this host, the other the account
+ * holder's own choice, and a relay backfilling decides whether to retry on
+ * exactly that distinction. Returns false with the response already filled in.
+ */
+static bool assert_repo_available(metalbear_server *server,
+                                  metalbear_account_context *acct,
+                                  const wf_xrpc_request *request,
+                                  wf_xrpc_response *response) {
+    if (!acct) {
+        wf_xrpc_response_set_error(response, 400, "RepoNotFound",
+                                   "Could not find repo");
+        return false;
+    }
+    /* The account itself always sees its own repository. */
+    if (request->authed_subject && acct->did &&
+        strcmp(request->authed_subject, acct->did) == 0)
+        return true;
+    char *ref = account_takedown_ref(server, acct->did);
+    if (ref) {
+        free(ref);
+        wf_xrpc_response_set_error(response, 400, "RepoTakendown",
+                                   "Repo has been takendown");
+        return false;
+    }
+    if (!metalbear_account_is_active(acct->account)) {
+        wf_xrpc_response_set_error(response, 400, "RepoDeactivated",
+                                   "Repo has been deactivated");
+        return false;
+    }
+    return true;
+}
+
+/*
+ * The repository layer's access guard, consulted by every route registered
+ * through metalbear_xrpc_server_register_pds_repo_resolver_ex. A read of the
+ * repository as a whole reports the availability errors; a single record
+ * reads as absent, which is both what the reference answers and the only
+ * thing `com.atproto.repo.getRecord` can say about a moderated record.
+ */
+static bool repo_access_guard(void *ctx, const wf_xrpc_request *req,
+                              const char *record_uri,
+                              wf_xrpc_response *resp) {
+    metalbear_server *server = ctx;
+    if (record_uri) {
+        char *ref = NULL;
+        metalbear_account_registry_get_takedown(server->registry, NULL,
+                                                record_uri, NULL, &ref);
+        if (!ref) return true;
+        free(ref);
+        wf_xrpc_response_set_error(resp, 404, "RecordNotFound",
+                                   "Could not locate record");
+        return false;
+    }
+    metalbear_account_context *acct = resolve_request_context(server, req);
+    /* An unresolvable account is the handler's own error to report, in the
+     * terms its lexicon uses. */
+    if (!acct) return true;
+    return assert_repo_available(server, acct, req, resp);
+}
+
 static cJSON *build_did_doc(metalbear_server *server,
                             metalbear_account_context *acct) {
     const char *signing_didkey =
@@ -1618,9 +1798,10 @@ static cJSON *session_json(metalbear_server *server,
     }
     cJSON_AddStringToObject(root, "handle", acct->handle);
     cJSON_AddStringToObject(root, "did", acct->did);
-    bool active = metalbear_account_is_active(acct->account);
+    bool active = false;
+    const char *status = account_status_string(server, acct, &active);
     cJSON_AddBoolToObject(root, "active", active);
-    if (!active) cJSON_AddStringToObject(root, "status", "deactivated");
+    if (status) cJSON_AddStringToObject(root, "status", status);
     char *email = NULL;
     int confirmed = 0;
     bool email_auth_factor = false;
@@ -1654,6 +1835,18 @@ static wf_status create_session(void *ctx, const wf_xrpc_request *request,
                  request->host_header ? request->host_header : "(unknown)");
         wf_xrpc_response_set_error(response, 401, "AuthenticationRequired",
                                    "Invalid identifier or password");
+        return WF_OK;
+    }
+    /*
+     * Credentials are checked before the takedown so the error does not
+     * distinguish a taken-down account from a wrong password to anyone who
+     * does not already hold the password.
+     */
+    if (account_is_taken_down(server, acct->did)) {
+        free(app_password_name);
+        LOG_WARN("create_session: refused taken-down account did=%s", acct->did);
+        wf_xrpc_response_set_error(response, 401, "AccountTakedown",
+                                   "Account has been taken down");
         return WF_OK;
     }
     metalbear_access_scope scope = credential == METALBEAR_CREDENTIAL_ACCOUNT
@@ -1694,6 +1887,11 @@ static wf_status refresh_session(void *ctx, const wf_xrpc_request *request,
     metalbear_server *server = ctx;
     metalbear_account_context *acct = resolve_request_context(server, request);
     const char *token = bearer_token(request->auth_header);
+    if (acct && account_is_taken_down(server, acct->did)) {
+        wf_xrpc_response_set_error(response, 401, "AccountTakedown",
+                                   "Account has been taken down");
+        return WF_OK;
+    }
     metalbear_session_tokens tokens = {0};
     if (!acct || metalbear_auth_rotate_refresh(acct->auth, token, &tokens) != WF_OK) {
         wf_xrpc_response_set_error(response, 401, "ExpiredToken",
@@ -2719,11 +2917,8 @@ static wf_status get_repo(void *ctx, const wf_xrpc_request *request,
         return WF_OK;
     }
     metalbear_account_context *acct = resolve_request_context(server, request);
-    if (!acct) {
-        wf_xrpc_response_set_error(response, 400, "RepoNotFound",
-                                   "Repository is not hosted here");
+    if (!assert_repo_available(server, acct, request, response))
         return WF_OK;
-    }
     unsigned char *data = NULL;
     size_t length = 0;
     wf_status status = metalbear_repo_store_export(
@@ -2748,11 +2943,8 @@ static wf_status get_blocks(void *ctx, const wf_xrpc_request *request,
         return WF_OK;
     }
     metalbear_account_context *acct = resolve_request_context(server, request);
-    if (!acct) {
-        wf_xrpc_response_set_error(response, 400, "RepoNotFound",
-                                   "Repository is not hosted here");
+    if (!assert_repo_available(server, acct, request, response))
         return WF_OK;
-    }
     const char **cids = NULL;
     size_t cid_count = 0;
     for (cJSON *item = request->params->child; item; item = item->next) {
@@ -2801,9 +2993,10 @@ static wf_status get_repo_status(void *ctx, const wf_xrpc_request *request,
     cJSON *root = cJSON_CreateObject();
     if (!root) return WF_ERR_ALLOC;
     cJSON_AddStringToObject(root, "did", acct->did);
-    bool active = metalbear_account_is_active(acct->account);
+    bool active = false;
+    const char *status = account_status_string(server, acct, &active);
     cJSON_AddBoolToObject(root, "active", active);
-    if (!active) cJSON_AddStringToObject(root, "status", "deactivated");
+    if (status) cJSON_AddStringToObject(root, "status", status);
     char *rev = NULL, *cid = NULL;
     if (active && metalbear_repo_store_get_head(acct->repo, &rev, &cid) == WF_OK)
         cJSON_AddStringToObject(root, "rev", rev);
@@ -2820,11 +3013,8 @@ static wf_status list_blobs(void *ctx, const wf_xrpc_request *request,
         ? cJSON_GetObjectItemCaseSensitive(request->params, "did") : NULL;
     metalbear_account_context *acct = cJSON_IsString(did)
         ? resolve_request_context(server, request) : NULL;
-    if (!acct) {
-        wf_xrpc_response_set_error(response, 400, "RepoNotFound",
-                                   "Repository is not hosted here");
+    if (!assert_repo_available(server, acct, request, response))
         return WF_OK;
-    }
     /* 'since' is accepted for lexicon compatibility; MetalBear's blob store
      * does not track per-blob revisions, so all available blobs are listed. */
     int limit = query_param_int(request->params, "limit", 500, 1, 1000);
@@ -3113,11 +3303,8 @@ static wf_status get_record(void *ctx, const wf_xrpc_request *request,
         return WF_OK;
     }
     metalbear_account_context *acct = resolve_request_context(server, request);
-    if (!acct) {
-        wf_xrpc_response_set_error(response, 400, "RepoNotFound",
-                                   "Repository is not hosted here");
+    if (!assert_repo_available(server, acct, request, response))
         return WF_OK;
-    }
     unsigned char *data = NULL;
     size_t length = 0;
     wf_status status = metalbear_repo_store_get_record_car(
@@ -4163,58 +4350,91 @@ static wf_status admin_get_subject_status(void *ctx,
                                    "at least one of did, uri, or blob is required");
         return WF_OK;
     }
+    /* A CID names content, not an upload, so a blob subject is only
+     * identifiable together with the account that holds it. */
+    if (blob && !did) {
+        wf_xrpc_response_set_error(response, 400, "InvalidRequest",
+                                   "Must provide a did to request blob state");
+        return WF_OK;
+    }
     cJSON *root = cJSON_CreateObject();
     if (!root) return WF_ERR_ALLOC;
-
-    /* Build subject union. */
     cJSON *subject = cJSON_CreateObject();
     if (!subject) { cJSON_Delete(root); return WF_ERR_ALLOC; }
-    if (did) {
+    cJSON_AddItemToObject(root, "subject", subject);
+
+    /*
+     * Blob first, then record, then account. A blob subject carries a DID as
+     * well as a CID, so testing `did` first would answer about the account
+     * that holds the blob instead of about the blob.
+     */
+    char *takedown_ref = NULL;
+    if (blob) {
+        metalbear_account_registry_get_takedown(server->registry, did, NULL,
+                                                blob, &takedown_ref);
+        if (!takedown_ref) {
+            cJSON_Delete(root);
+            wf_xrpc_response_set_error(response, 400, "NotFound",
+                                       "Subject not found");
+            return WF_OK;
+        }
+        cJSON_AddStringToObject(subject, "$type",
+                                "com.atproto.admin.defs#repoBlobRef");
+        cJSON_AddStringToObject(subject, "did", did);
+        cJSON_AddStringToObject(subject, "cid", blob);
+    } else if (uri) {
+        /* `com.atproto.repo.strongRef` requires `cid`, so the record is
+         * resolved to supply one; a strict client rejects a reference that
+         * carries only the URI. */
+        char authority[256], collection[256], rkey[256];
+        char *record_cid = NULL;
+        if (split_at_uri(uri, authority, sizeof authority,
+                         collection, sizeof collection, rkey, sizeof rkey)) {
+            metalbear_account_context *acct =
+                context_for_identifier(server, authority);
+            char *record_json = NULL;
+            if (acct && metalbear_repo_store_get_record(
+                    acct->repo, collection, rkey,
+                    &record_json, &record_cid) != WF_OK)
+                record_cid = NULL;
+            free(record_json);
+        }
+        if (record_cid)
+            metalbear_account_registry_get_takedown(server->registry, NULL, uri,
+                                                    NULL, &takedown_ref);
+        if (!record_cid || !takedown_ref) {
+            free(record_cid);
+            free(takedown_ref);
+            cJSON_Delete(root);
+            wf_xrpc_response_set_error(response, 400, "NotFound",
+                                       "Subject not found");
+            return WF_OK;
+        }
+        cJSON_AddStringToObject(subject, "$type", "com.atproto.repo.strongRef");
+        cJSON_AddStringToObject(subject, "uri", uri);
+        cJSON_AddStringToObject(subject, "cid", record_cid);
+        free(record_cid);
+    } else {
+        metalbear_account_entry *entry = NULL;
+        if (metalbear_account_registry_find_by_did(
+                server->registry, did, &entry) != WF_OK || !entry) {
+            cJSON_Delete(root);
+            wf_xrpc_response_set_error(response, 400, "NotFound",
+                                       "Subject not found");
+            return WF_OK;
+        }
+        metalbear_account_registry_get_takedown(server->registry, did, NULL,
+                                                NULL, &takedown_ref);
         cJSON_AddStringToObject(subject, "$type",
                                 "com.atproto.admin.defs#repoRef");
         cJSON_AddStringToObject(subject, "did", did);
-    } else if (uri) {
-        cJSON_AddStringToObject(subject, "$type",
-                                "com.atproto.repo.strongRef");
-        cJSON_AddStringToObject(subject, "uri", uri);
-    } else {
-        cJSON_AddStringToObject(subject, "$type",
-                                "com.atproto.admin.defs#repoBlobRef");
-        /* repoBlobRef requires did+cid; extract from blob CID or require did. */
-        cJSON_AddStringToObject(subject, "did", did ? did : "");
-        cJSON_AddStringToObject(subject, "cid", blob);
+        cJSON_AddItemToObject(root, "deactivated",
+                              status_attr(!entry->active, NULL));
+        metalbear_account_entry_free(entry);
     }
-    cJSON_AddItemToObject(root, "subject", subject);
-
-    /* Check takedown status. */
-    char *takedown_ref = NULL;
-    if (metalbear_account_registry_get_takedown(
-            server->registry, did, uri, blob, &takedown_ref) == WF_OK &&
-        takedown_ref) {
-        cJSON *td = cJSON_CreateObject();
-        if (td) {
-            cJSON_AddBoolToObject(td, "applied", true);
-            cJSON_AddStringToObject(td, "ref", takedown_ref);
-            cJSON_AddItemToObject(root, "takedown", td);
-        }
-        free(takedown_ref);
-    }
-
-    /* Check deactivation status (accounts only). */
-    if (did) {
-        metalbear_account_entry *entry = NULL;
-        if (metalbear_account_registry_find_by_did(
-                server->registry, did, &entry) == WF_OK && entry) {
-            if (!entry->active) {
-                cJSON *deact = cJSON_CreateObject();
-                if (deact) {
-                    cJSON_AddBoolToObject(deact, "applied", true);
-                    cJSON_AddItemToObject(root, "deactivated", deact);
-                }
-            }
-            metalbear_account_entry_free(entry);
-        }
-    }
+    cJSON_AddItemToObject(root, "takedown",
+                          status_attr(takedown_ref != NULL, takedown_ref));
+    free(takedown_ref);
     return set_json(response, root);
 }
 
@@ -4278,37 +4498,70 @@ static wf_status admin_update_subject_status(void *ctx,
         return WF_OK;
     }
 
+    bool account_subject = did && !uri && !blob_cid;
+    cJSON *takedown_applied = takedown
+        ? cJSON_GetObjectItemCaseSensitive(takedown, "applied") : NULL;
+    cJSON *deactivated_applied = deactivated
+        ? cJSON_GetObjectItemCaseSensitive(deactivated, "applied") : NULL;
+
+    /* The two would race to decide the account's status and the event that
+     * announces it, so the reference refuses the pair outright. */
+    if (cJSON_IsTrue(takedown_applied) && deactivated &&
+        !cJSON_IsTrue(deactivated_applied)) {
+        wf_xrpc_response_set_error(
+            response, 400, "InvalidRequest",
+            "Cannot activate and takedown an account at the same time");
+        return WF_OK;
+    }
+
     /* Apply takedown if present. */
     if (takedown) {
-        cJSON *applied = cJSON_GetObjectItemCaseSensitive(takedown, "applied");
         cJSON *ref = cJSON_GetObjectItemCaseSensitive(takedown, "ref");
         const char *ref_str = cJSON_IsString(ref) ? ref->valuestring : "admin";
-        if (cJSON_IsTrue(applied)) {
-            metalbear_account_registry_set_takedown(
-                server->registry, did, uri, blob_cid, ref_str);
-        } else {
-            metalbear_account_registry_set_takedown(
-                server->registry, did, uri, blob_cid, NULL);
+        bool applying = cJSON_IsTrue(takedown_applied);
+        metalbear_account_registry_set_takedown(
+            server->registry, did, uri, blob_cid,
+            applying ? ref_str : NULL);
+        /*
+         * Every session the account holds is revoked, so a takedown takes
+         * effect on the tokens already issued rather than only on new logins.
+         * Lifting it does not restore them: the holder logs in again.
+         */
+        if (account_subject && applying) {
+            metalbear_account_context *acct = context_for_did(server, did);
+            if (acct) metalbear_auth_delete_all(acct->auth);
+            LOG_INFO("takedown: applied to did=%s ref=%s", did, ref_str);
+        } else if (account_subject) {
+            LOG_INFO("takedown: lifted from did=%s", did);
         }
     }
 
     /* Handle account deactivation (repoRef only). */
-    if (deactivated && did && !uri && !blob_cid) {
-        cJSON *applied = cJSON_GetObjectItemCaseSensitive(deactivated, "applied");
-        if (cJSON_IsTrue(applied)) {
-            metalbear_account_context *acct = context_for_did(server, did);
-            if (acct) {
+    if (deactivated && account_subject) {
+        metalbear_account_context *acct = context_for_did(server, did);
+        if (acct) {
+            if (cJSON_IsTrue(deactivated_applied))
                 metalbear_account_deactivate(acct->account, NULL);
-                metalbear_sequencer_account_status(
-                    acct->sequencer, did, 0, "deactivated");
-            }
-        } else {
-            metalbear_account_context *acct = context_for_did(server, did);
-            if (acct) {
+            else
                 metalbear_account_activate(acct->account);
-                metalbear_sequencer_account_status(
-                    acct->sequencer, did, 1, NULL);
-            }
+        }
+    }
+
+    /*
+     * Announce the resulting status once, whatever changed. Sequenced against
+     * the server's own log rather than a resolved context's, so the event is
+     * not silently skipped for an account that happens not to be cached —
+     * and computed after both changes have been applied, so an account that
+     * is deactivated *and* taken down is announced as taken down rather than
+     * as whichever call ran last.
+     */
+    if (account_subject) {
+        metalbear_account_context *acct = context_for_did(server, did);
+        if (acct) {
+            bool active = false;
+            const char *status = account_status_string(server, acct, &active);
+            metalbear_sequencer_account_status(server->sequencer, did,
+                                               active ? 1 : 0, status);
         }
     }
 
@@ -4802,6 +5055,10 @@ static wf_status admin_delete_account(void *ctx,
                                        "deleted");
 
     metalbear_account_registry_remove(server->registry, did->valuestring);
+    /* Moderation state goes with it: a DID re-registered later must not
+     * inherit the deleted account's takedowns. */
+    metalbear_account_registry_clear_takedowns_for_did(server->registry,
+                                                       did->valuestring);
 
     /* Drop the handle's TXT record: leaving it would keep pointing resolvers
      * at a DID this host no longer serves. */
@@ -5492,6 +5749,21 @@ static wf_status upload_blob(void *ctx, const wf_xrpc_request *request,
                                     "failed to encode blob CID");
         return WF_OK;
     }
+    /*
+     * Checked after hashing, because the CID is what a takedown names and it
+     * is not known until the body has been read. A takedown that blocked only
+     * reads would be undone by re-uploading the same bytes.
+     */
+    char *blob_takedown = NULL;
+    metalbear_account_registry_get_takedown(server->registry, acct->did, NULL,
+                                            cid_str, &blob_takedown);
+    if (blob_takedown) {
+        free(blob_takedown);
+        free(cid_str);
+        wf_xrpc_response_set_error(response, 400, "InvalidRequest",
+                                    "Blob has been takendown, cannot re-upload");
+        return WF_OK;
+    }
     if (metalbear_blob_store_put(acct->blobs, cid_str, mime,
                            request->body, request->body_len) != WF_OK) {
         free(cid_str);
@@ -5542,6 +5814,19 @@ static wf_status get_blob(void *ctx, const wf_xrpc_request *request,
     if (!acct) {
         wf_xrpc_response_set_error(response, 404, "BlobNotFound",
                                     "account is not hosted here");
+        return WF_OK;
+    }
+    if (!assert_repo_available(server, acct, request, response))
+        return WF_OK;
+    /* A taken-down blob reads as absent: the lexicon has no code for a
+     * moderated blob, and BlobNotFound is what the reference answers. */
+    char *blob_takedown = NULL;
+    metalbear_account_registry_get_takedown(server->registry, acct->did, NULL,
+                                            cid->valuestring, &blob_takedown);
+    if (blob_takedown) {
+        free(blob_takedown);
+        wf_xrpc_response_set_error(response, 404, "BlobNotFound",
+                                    "no blob stored for the given CID");
         return WF_OK;
     }
     unsigned char *data = NULL;
@@ -5759,10 +6044,11 @@ static wf_status list_repos(void *ctx, const wf_xrpc_request *request,
         cJSON_AddStringToObject(repo, "did", acct->did);
         cJSON_AddStringToObject(repo, "head", cid);
         cJSON_AddStringToObject(repo, "rev", rev);
-        bool active = metalbear_account_is_active(acct->account);
+        bool active = false;
+        const char *status = account_status_string(server, acct, &active);
         cJSON_AddBoolToObject(repo, "active", active);
-        if (!active)
-            cJSON_AddStringToObject(repo, "status", "deactivated");
+        if (status)
+            cJSON_AddStringToObject(repo, "status", status);
         cJSON_AddItemToArray(repos, repo);
         emitted++;
         free(rev);
@@ -6048,7 +6334,9 @@ static wf_status landing_handler(void *ctx, const wf_xrpc_request *req,
         for (size_t i = 0; i < count; i++) {
             char *handle = html_escape(entries[i].handle);
             char *did = html_escape(entries[i].did);
-            const char *state = entries[i].active ? "active" : "deactivated";
+            const char *state =
+                account_is_taken_down(server, entries[i].did) ? "takendown"
+                : entries[i].active ? "active" : "deactivated";
             bool ok = handle && did &&
                 sb_append(&sb,
                           "<li><code>%s</code> — <code>%s</code> "
@@ -6699,7 +6987,8 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
         metalbear_xrpc_server_register_pds_repo_resolver_ex(server->xrpc,
             metalbear_repo_resolver, server,
             server->service_did, server->public_url,
-            resolve_did_doc_json, server, server->lexicons) != WF_OK ||
+            resolve_did_doc_json, server, server->lexicons,
+            repo_access_guard, server) != WF_OK ||
         wf_xrpc_server_register_procedure(server->xrpc,
             "com.atproto.repo.uploadBlob", upload_blob, server) != WF_OK ||
         wf_xrpc_server_register_query(server->xrpc,

--- a/test/test_multi_account.c
+++ b/test/test_multi_account.c
@@ -669,6 +669,75 @@ int main(void) {
     }
 
     /*
+     * Paging holds when the registry changes underneath it.
+     *
+     * The cursor used to be a row offset, which counts positions in a list
+     * that shifts as accounts are created and deleted: an account moving into
+     * a slot already read is never returned, and one moving out is returned
+     * twice. A relay backfilling a host is exactly the client that walks
+     * every page and exactly the one that must not silently miss a repo.
+     *
+     * Walk one repository at a time, creating an account that sorts before
+     * everything already returned, and check that the accounts seen are
+     * distinct and that the walk still reaches all of them.
+     */
+    {
+        char seen[8][128];
+        size_t seen_count = 0;
+        char cursor[128] = "";
+        bool duplicated = false;
+        for (int page = 0; page < 8; page++) {
+            wf_response response = {0};
+            wf_xrpc_param params[] = {{"limit", "1"}, {"cursor", cursor}};
+            CHECK(wf_xrpc_query_params(client, "com.atproto.sync.listRepos",
+                                       params, cursor[0] ? 2 : 1,
+                                       &response) == WF_OK);
+            cJSON *json = json_response(&response);
+            cJSON *repos = cJSON_GetObjectItemCaseSensitive(json, "repos");
+            cJSON *next = cJSON_GetObjectItemCaseSensitive(json, "cursor");
+            cJSON *repo = NULL;
+            cJSON_ArrayForEach(repo, repos) {
+                cJSON *did = cJSON_GetObjectItemCaseSensitive(repo, "did");
+                if (!cJSON_IsString(did)) continue;
+                for (size_t i = 0; i < seen_count; i++)
+                    if (strcmp(seen[i], did->valuestring) == 0)
+                        duplicated = true;
+                if (seen_count < 8)
+                    snprintf(seen[seen_count++], 128, "%s", did->valuestring);
+            }
+            bool more = cJSON_IsString(next);
+            if (more) snprintf(cursor, sizeof(cursor), "%s", next->valuestring);
+            cJSON_Delete(json);
+            wf_response_free(&response);
+            if (!more) break;
+            /* A new account appears mid-walk. Its DID sorts first, so an
+             * offset cursor would shift every unread row by one. */
+            if (page == 0) {
+                char *token = create_account(client, "aaron.example.com",
+                                             "did:plc:aaron", "aaronsecret");
+                CHECK(token != NULL);
+                if (token) {
+                    wf_xrpc_client_set_auth(client, token);
+                    CHECK(create_record(client, "did:plc:aaron", "hello",
+                                        "hi") == 200);
+                    wf_xrpc_client_set_auth(client, NULL);
+                }
+                free(token);
+            }
+        }
+        CHECK(!duplicated);
+        /* Bob and Carol both have repositories and must both have been seen,
+         * whatever the new account did to the ordering. */
+        bool saw_bob = false, saw_carol = false;
+        for (size_t i = 0; i < seen_count; i++) {
+            if (strcmp(seen[i], "did:plc:bob") == 0) saw_bob = true;
+            if (strcmp(seen[i], "did:plc:carol") == 0) saw_carol = true;
+        }
+        CHECK(saw_bob);
+        CHECK(saw_carol);
+    }
+
+    /*
      * applyWrites is atomic: three writes land as exactly ONE #commit.
      *
      * This used to be asserted through the commit's `prev` link, but v3

--- a/test/test_takedown.c
+++ b/test/test_takedown.c
@@ -1,0 +1,558 @@
+#define _POSIX_C_SOURCE 200809L
+#define _DARWIN_C_SOURCE
+
+/*
+ * test_takedown.c — offline end-to-end coverage for the moderation model:
+ * account, record and blob takedowns applied through
+ * com.atproto.admin.updateSubjectStatus.
+ *
+ * The properties under test are the ones a takedown is worth nothing without:
+ *
+ *   (a) a taken-down account reports `takendown` — not `deactivated` — from
+ *       every endpoint that reports a status, and takedown outranks
+ *       deactivation when both apply,
+ *   (b) its repository stops being readable, with `RepoTakendown`
+ *       distinguished from `RepoDeactivated` so a consumer can tell a
+ *       moderation action from the account holder's own choice,
+ *   (c) its existing sessions stop working and it cannot log in again,
+ *   (d) a taken-down record reads as absent while the rest of the repository
+ *       still serves,
+ *   (e) a taken-down blob cannot be fetched and cannot be re-uploaded, and
+ *       the takedown is scoped to the account that holds it rather than to
+ *       the CID, which names content and may be shared,
+ *   (f) lifting a takedown restores all of the above,
+ *   (g) the firehose is told: the takedown and its lifting each produce an
+ *       #account event carrying the new status.
+ *
+ * Cleanup removes the whole data directory, every per-account SQLite file and
+ * blob directory included.
+ */
+
+#include "metalbear/server.h"
+#include "wolfram/xrpc.h"
+
+#include <cJSON.h>
+#include <ftw.h>
+#include <openssl/evp.h>
+#include <sqlite3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int rmtree_remove_cb(const char *path, const struct stat *sb,
+                            int type, struct FTW *ftwbuf) {
+    (void)sb; (void)type; (void)ftwbuf;
+    return remove(path);
+}
+static void rmtree(const char *path) {
+    nftw(path, rmtree_remove_cb, 64, FTW_DEPTH | FTW_PHYS);
+}
+
+static int failures;
+#define CHECK(expr) do { if (!(expr)) { \
+    fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    failures++; } } while (0)
+
+static cJSON *json_response(wf_response *response) {
+    return cJSON_ParseWithLength(response->body ? response->body : "",
+                                 response->body_len);
+}
+
+/* The `error` name from an XRPC error body, or "" when there is none.
+ * Copied into `out` because the parsed tree is freed here. */
+static void error_name(wf_response *response, char *out, size_t out_len) {
+    out[0] = '\0';
+    cJSON *json = json_response(response);
+    cJSON *error = cJSON_GetObjectItemCaseSensitive(json, "error");
+    if (cJSON_IsString(error)) snprintf(out, out_len, "%s", error->valuestring);
+    cJSON_Delete(json);
+}
+
+/* POST an admin-gated XRPC method with HTTP Basic `admin:<password>`. */
+static wf_status admin_post(wf_xrpc_client *client, const char *base,
+                            const char *nsid, const char *body,
+                            wf_response *out) {
+    char cred[64];
+    int n = snprintf(cred, sizeof(cred), "admin:%s", "secret-admin");
+    char b64[128];
+    int len = EVP_EncodeBlock((unsigned char *)b64,
+                              (const unsigned char *)cred, n);
+    b64[len] = '\0';
+    char auth[160];
+    snprintf(auth, sizeof(auth), "Basic %s", b64);
+    wf_http_header hdr = {"Authorization", auth};
+    char url[256];
+    snprintf(url, sizeof(url), "%s/xrpc/%s", base, nsid);
+    return wf_http_post(client, url, "application/json", body, &hdr, 1, out);
+}
+
+/* GET an admin-gated XRPC method with HTTP Basic. */
+static wf_status admin_get(wf_xrpc_client *client, const char *base,
+                           const char *query, wf_response *out) {
+    char cred[64];
+    int n = snprintf(cred, sizeof(cred), "admin:%s", "secret-admin");
+    char b64[128];
+    int len = EVP_EncodeBlock((unsigned char *)b64,
+                              (const unsigned char *)cred, n);
+    b64[len] = '\0';
+    char auth[160];
+    snprintf(auth, sizeof(auth), "Basic %s", b64);
+    wf_http_header hdr = {"Authorization", auth};
+    char url[512];
+    snprintf(url, sizeof(url), "%s/xrpc/%s", base, query);
+    return wf_http_get_with_headers(client, url, &hdr, 1, out);
+}
+
+/* Apply or lift an account takedown. Returns the HTTP status. */
+static long set_account_takedown(wf_xrpc_client *client, const char *base,
+                                 const char *did, bool applied) {
+    char body[512];
+    snprintf(body, sizeof(body),
+             "{\"subject\":{\"$type\":\"com.atproto.admin.defs#repoRef\","
+             "\"did\":\"%s\"},\"takedown\":{\"applied\":%s,"
+             "\"ref\":\"moderation-1\"}}",
+             did, applied ? "true" : "false");
+    wf_response response = {0};
+    admin_post(client, base, "com.atproto.admin.updateSubjectStatus", body,
+               &response);
+    long status = response.status;
+    wf_response_free(&response);
+    return status;
+}
+
+static char *create_account(wf_xrpc_client *client, const char *handle,
+                            const char *did, const char *password) {
+    char body[512];
+    snprintf(body, sizeof(body),
+             "{\"handle\":\"%s\",\"password\":\"%s\",\"did\":\"%s\","
+             "\"email\":\"%s@example.com\"}",
+             handle, password, did, handle);
+    wf_response response = {0};
+    if (wf_xrpc_procedure(client, "com.atproto.server.createAccount", body,
+                          &response) != WF_OK || response.status != 200) {
+        wf_response_free(&response);
+        return NULL;
+    }
+    cJSON *json = json_response(&response);
+    cJSON *access = cJSON_GetObjectItemCaseSensitive(json, "accessJwt");
+    char *token = cJSON_IsString(access) ? strdup(access->valuestring) : NULL;
+    cJSON_Delete(json);
+    wf_response_free(&response);
+    return token;
+}
+
+static long create_record(wf_xrpc_client *client, const char *repo,
+                          const char *rkey, const char *text) {
+    char body[512];
+    snprintf(body, sizeof(body),
+             "{\"repo\":\"%s\",\"collection\":\"app.bsky.feed.post\","
+             "\"rkey\":\"%s\",\"record\":{\"$type\":\"app.bsky.feed.post\","
+             "\"text\":\"%s\",\"createdAt\":\"2026-07-27T00:00:00.000Z\"}}",
+             repo, rkey, text);
+    wf_response response = {0};
+    wf_xrpc_procedure(client, "com.atproto.repo.createRecord", body, &response);
+    long status = response.status;
+    wf_response_free(&response);
+    return status;
+}
+
+static long get_record(wf_xrpc_client *client, const char *repo,
+                       const char *rkey) {
+    wf_xrpc_param params[] = {
+        {"repo", repo},
+        {"collection", "app.bsky.feed.post"},
+        {"rkey", rkey},
+    };
+    wf_response response = {0};
+    wf_xrpc_query_params(client, "com.atproto.repo.getRecord", params, 3,
+                         &response);
+    long status = response.status;
+    wf_response_free(&response);
+    return status;
+}
+
+/* Upload a blob and copy its CID out. Returns the HTTP status. */
+static long upload_blob(wf_xrpc_client *client, const char *base,
+                        const char *token, const char *bytes,
+                        char *out_cid, size_t out_len) {
+    char url[256];
+    snprintf(url, sizeof(url), "%s/xrpc/com.atproto.repo.uploadBlob", base);
+    char auth[1024];
+    snprintf(auth, sizeof(auth), "Bearer %s", token);
+    wf_http_header hdr = {"Authorization", auth};
+    wf_response response = {0};
+    wf_http_post(client, url, "text/plain", bytes, &hdr, 1, &response);
+    long status = response.status;
+    if (status == 200 && out_cid && out_len) {
+        cJSON *json = json_response(&response);
+        cJSON *blob = cJSON_GetObjectItemCaseSensitive(json, "blob");
+        cJSON *ref = cJSON_GetObjectItemCaseSensitive(blob, "ref");
+        cJSON *link = cJSON_GetObjectItemCaseSensitive(ref, "$link");
+        if (cJSON_IsString(link)) snprintf(out_cid, out_len, "%s",
+                                          link->valuestring);
+        cJSON_Delete(json);
+    }
+    wf_response_free(&response);
+    return status;
+}
+
+/*
+ * Count #account frames in the host log naming `did` and carrying `status`.
+ * The frame stores both as text, so searching the bytes avoids decoding
+ * DAG-CBOR here — the same approach the multi-account test takes.
+ */
+static int count_account_events(const char *seq_path, const char *did,
+                                const char *status) {
+    sqlite3 *db = NULL;
+    int found = 0;
+    if (sqlite3_open(seq_path, &db) == SQLITE_OK) {
+        sqlite3_stmt *stmt = NULL;
+        if (sqlite3_prepare_v2(db,
+                "SELECT COUNT(*) FROM events WHERE instr(frame, '#account') > 0"
+                " AND instr(frame, ?) > 0 AND instr(frame, ?) > 0;",
+                -1, &stmt, NULL) == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, did, -1, SQLITE_STATIC);
+            sqlite3_bind_text(stmt, 2, status, -1, SQLITE_STATIC);
+            if (sqlite3_step(stmt) == SQLITE_ROW)
+                found = sqlite3_column_int(stmt, 0);
+        }
+        sqlite3_finalize(stmt);
+    }
+    sqlite3_close(db);
+    return found;
+}
+
+int main(void) {
+    char directory[] = "/tmp/metalbear-takedown-XXXXXX";
+    CHECK(mkdtemp(directory) != NULL);
+    metalbear_config config = {
+        .listen_address = "127.0.0.1",
+        .port = 0,
+        .thread_count = 2,
+        .data_directory = directory,
+        .service_did = "did:web:pds.example.com",
+        .user_domain = ".example.com",
+        .admin_password = "secret-admin",
+        .invite_required = false,
+    };
+    metalbear_server *server = metalbear_server_start(&config);
+    CHECK(server != NULL);
+    if (!server) { rmtree(directory); return 1; }
+
+    char base[80];
+    snprintf(base, sizeof(base), "http://127.0.0.1:%u",
+             (unsigned)metalbear_server_port(server));
+    wf_xrpc_client *client = wf_xrpc_client_new(base);
+    CHECK(client != NULL);
+
+    const char *mallory_did = "did:plc:mallory";
+    const char *victim_did = "did:plc:victim";
+    char *mallory = create_account(client, "mallory.example.com", mallory_did,
+                                   "mallorysecret");
+    char *victim = create_account(client, "victim.example.com", victim_did,
+                                  "victimsecret");
+    CHECK(mallory != NULL);
+    CHECK(victim != NULL);
+    if (!mallory || !victim) goto done;
+
+    /* Both accounts write a record, and both upload the same bytes, so the
+     * blob CID is genuinely shared between two accounts. */
+    wf_xrpc_client_set_auth(client, mallory);
+    CHECK(create_record(client, mallory_did, "keep", "kept") == 200);
+    CHECK(create_record(client, mallory_did, "bad", "offending") == 200);
+    char mallory_blob[128] = "";
+    CHECK(upload_blob(client, base, mallory, "shared bytes",
+                      mallory_blob, sizeof(mallory_blob)) == 200);
+    CHECK(mallory_blob[0] != '\0');
+
+    wf_xrpc_client_set_auth(client, victim);
+    char victim_blob[128] = "";
+    CHECK(upload_blob(client, base, victim, "shared bytes",
+                      victim_blob, sizeof(victim_blob)) == 200);
+    /* Same bytes, so necessarily the same CID: this is what makes a takedown
+     * keyed on the CID alone a bug rather than a shortcut. */
+    CHECK(strcmp(mallory_blob, victim_blob) == 0);
+
+    wf_response response = {0};
+    char err[64];
+
+    /* ---- (d) record takedown ------------------------------------------- */
+    {
+        char body[640];
+        snprintf(body, sizeof(body),
+                 "{\"subject\":{\"$type\":\"com.atproto.repo.strongRef\","
+                 "\"uri\":\"at://%s/app.bsky.feed.post/bad\","
+                 "\"cid\":\"unused\"},"
+                 "\"takedown\":{\"applied\":true,\"ref\":\"mod-record\"}}",
+                 mallory_did);
+        CHECK(admin_post(client, base, "com.atproto.admin.updateSubjectStatus",
+                         body, &response) == WF_OK);
+        CHECK(response.status == 200);
+        wf_response_free(&response);
+    }
+    wf_xrpc_client_set_auth(client, NULL);
+    /* The taken-down record reads as absent; its neighbour still serves. */
+    CHECK(get_record(client, mallory_did, "bad") == 404);
+    CHECK(get_record(client, mallory_did, "keep") == 200);
+
+    /* getSubjectStatus reports it, and the strongRef it echoes carries the
+     * `cid` the lexicon requires — a reference without one is unusable. */
+    {
+        char query[512];
+        snprintf(query, sizeof(query),
+                 "com.atproto.admin.getSubjectStatus?uri=at://%s/"
+                 "app.bsky.feed.post/bad", mallory_did);
+        CHECK(admin_get(client, base, query, &response) == WF_OK);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        cJSON *subject = cJSON_GetObjectItemCaseSensitive(json, "subject");
+        cJSON *cid = cJSON_GetObjectItemCaseSensitive(subject, "cid");
+        cJSON *takedown = cJSON_GetObjectItemCaseSensitive(json, "takedown");
+        cJSON *applied = cJSON_GetObjectItemCaseSensitive(takedown, "applied");
+        CHECK(cJSON_IsString(cid) && cid->valuestring[0]);
+        CHECK(cJSON_IsTrue(applied));
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* ---- (e) blob takedown, scoped to one account ----------------------- */
+    {
+        char body[640];
+        snprintf(body, sizeof(body),
+                 "{\"subject\":{\"$type\":\"com.atproto.admin.defs#repoBlobRef\","
+                 "\"did\":\"%s\",\"cid\":\"%s\"},"
+                 "\"takedown\":{\"applied\":true,\"ref\":\"mod-blob\"}}",
+                 mallory_did, mallory_blob);
+        CHECK(admin_post(client, base, "com.atproto.admin.updateSubjectStatus",
+                         body, &response) == WF_OK);
+        CHECK(response.status == 200);
+        wf_response_free(&response);
+    }
+    {
+        wf_xrpc_param params[] = {{"did", mallory_did}, {"cid", mallory_blob}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getBlob", params, 2,
+                             &response);
+        CHECK(response.status == 404);
+        wf_response_free(&response);
+        /* The other account stored the same bytes and is unaffected. */
+        wf_xrpc_param others[] = {{"did", victim_did}, {"cid", victim_blob}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getBlob", others, 2,
+                             &response);
+        CHECK(response.status == 200);
+        wf_response_free(&response);
+    }
+    /* Re-uploading the same bytes must not quietly undo the takedown. */
+    CHECK(upload_blob(client, base, mallory, "shared bytes", NULL, 0) == 400);
+
+    /* The account itself is not taken down by its blob's takedown. */
+    {
+        wf_xrpc_param params[] = {{"did", mallory_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        CHECK(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(json, "active")));
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* ---- (a)(b)(c) account takedown ------------------------------------ */
+    CHECK(set_account_takedown(client, base, mallory_did, true) == 200);
+
+    {
+        wf_xrpc_param params[] = {{"did", mallory_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        cJSON *status = cJSON_GetObjectItemCaseSensitive(json, "status");
+        CHECK(cJSON_IsFalse(cJSON_GetObjectItemCaseSensitive(json, "active")));
+        CHECK(cJSON_IsString(status) &&
+              strcmp(status->valuestring, "takendown") == 0);
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* (b) the repository stops serving, under a name that says why. */
+    {
+        wf_xrpc_param params[] = {{"did", mallory_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepo", params, 1,
+                             &response);
+        CHECK(response.status == 400);
+        error_name(&response, err, sizeof(err));
+        CHECK(strcmp(err, "RepoTakendown") == 0);
+        wf_response_free(&response);
+
+        wf_xrpc_query_params(client, "com.atproto.sync.listBlobs", params, 1,
+                             &response);
+        CHECK(response.status == 400);
+        error_name(&response, err, sizeof(err));
+        CHECK(strcmp(err, "RepoTakendown") == 0);
+        wf_response_free(&response);
+
+        wf_xrpc_query_params(client, "com.atproto.sync.getLatestCommit", params,
+                             1, &response);
+        CHECK(response.status == 400);
+        error_name(&response, err, sizeof(err));
+        CHECK(strcmp(err, "RepoTakendown") == 0);
+        wf_response_free(&response);
+    }
+
+    /* Even the record that was never moderated is now unreadable. */
+    CHECK(get_record(client, mallory_did, "keep") == 400);
+
+    /* The handle stops resolving, as it does for an account that is gone. */
+    {
+        wf_xrpc_param params[] = {{"handle", "mallory.example.com"}};
+        wf_xrpc_query_params(client, "com.atproto.identity.resolveHandle",
+                             params, 1, &response);
+        CHECK(response.status == 400);
+        wf_response_free(&response);
+    }
+
+    /* listRepos reports the status rather than omitting the account. */
+    {
+        wf_xrpc_query(client, "com.atproto.sync.listRepos", NULL, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        cJSON *repos = cJSON_GetObjectItemCaseSensitive(json, "repos");
+        bool saw_takendown = false;
+        cJSON *repo = NULL;
+        cJSON_ArrayForEach(repo, repos) {
+            cJSON *did = cJSON_GetObjectItemCaseSensitive(repo, "did");
+            cJSON *status = cJSON_GetObjectItemCaseSensitive(repo, "status");
+            if (cJSON_IsString(did) &&
+                strcmp(did->valuestring, mallory_did) == 0 &&
+                cJSON_IsString(status) &&
+                strcmp(status->valuestring, "takendown") == 0)
+                saw_takendown = true;
+        }
+        CHECK(saw_takendown);
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* (c) the session it already held is dead, and it cannot get a new one. */
+    wf_xrpc_client_set_auth(client, mallory);
+    wf_xrpc_query(client, "com.atproto.server.getSession", NULL, &response);
+    CHECK(response.status == 401);
+    wf_response_free(&response);
+    wf_xrpc_client_set_auth(client, NULL);
+    {
+        const char *body = "{\"identifier\":\"mallory.example.com\","
+                           "\"password\":\"mallorysecret\"}";
+        wf_xrpc_procedure(client, "com.atproto.server.createSession", body,
+                          &response);
+        CHECK(response.status == 401);
+        error_name(&response, err, sizeof(err));
+        CHECK(strcmp(err, "AccountTakedown") == 0);
+        wf_response_free(&response);
+    }
+
+    /* The untouched account is entirely unaffected. */
+    {
+        wf_xrpc_param params[] = {{"did", victim_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        CHECK(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(json, "active")));
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* A takedown may not be paired with a reactivation: the two disagree
+     * about what the account's status should become. */
+    {
+        char body[400];
+        snprintf(body, sizeof(body),
+                 "{\"subject\":{\"$type\":\"com.atproto.admin.defs#repoRef\","
+                 "\"did\":\"%s\"},\"takedown\":{\"applied\":true},"
+                 "\"deactivated\":{\"applied\":false}}", victim_did);
+        /* A refusal comes back as WF_ERR_HTTP, so only the status is checked. */
+        admin_post(client, base, "com.atproto.admin.updateSubjectStatus", body,
+                   &response);
+        CHECK(response.status == 400);
+        wf_response_free(&response);
+        /* And it changed nothing: the account is still active. */
+        wf_xrpc_param params[] = {{"did", victim_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        cJSON *json = json_response(&response);
+        CHECK(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(json, "active")));
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /* ---- (g) the firehose was told ------------------------------------- */
+    char seq_path[512];
+    snprintf(seq_path, sizeof(seq_path), "%s/sequencer.sqlite3", directory);
+    CHECK(count_account_events(seq_path, mallory_did, "takendown") >= 1);
+
+    /* ---- (f) lifting it restores everything ---------------------------- */
+    CHECK(set_account_takedown(client, base, mallory_did, false) == 200);
+    {
+        wf_xrpc_param params[] = {{"did", mallory_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        CHECK(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(json, "active")));
+        CHECK(!cJSON_GetObjectItemCaseSensitive(json, "status"));
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+    CHECK(get_record(client, mallory_did, "keep") == 200);
+    /* The record's own takedown outlives the account's: lifting one does not
+     * lift the other. */
+    CHECK(get_record(client, mallory_did, "bad") == 404);
+    {
+        const char *body = "{\"identifier\":\"mallory.example.com\","
+                           "\"password\":\"mallorysecret\"}";
+        wf_xrpc_procedure(client, "com.atproto.server.createSession", body,
+                          &response);
+        CHECK(response.status == 200);
+        wf_response_free(&response);
+    }
+
+    /* A deactivated account that is also taken down reports the takedown:
+     * the moderation action is the one a consumer must not misread. */
+    CHECK(set_account_takedown(client, base, mallory_did, true) == 200);
+    {
+        char body[400];
+        snprintf(body, sizeof(body),
+                 "{\"subject\":{\"$type\":\"com.atproto.admin.defs#repoRef\","
+                 "\"did\":\"%s\"},\"deactivated\":{\"applied\":true}}",
+                 mallory_did);
+        CHECK(admin_post(client, base, "com.atproto.admin.updateSubjectStatus",
+                         body, &response) == WF_OK);
+        CHECK(response.status == 200);
+        wf_response_free(&response);
+
+        wf_xrpc_param params[] = {{"did", mallory_did}};
+        wf_xrpc_query_params(client, "com.atproto.sync.getRepoStatus", params,
+                             1, &response);
+        CHECK(response.status == 200);
+        cJSON *json = json_response(&response);
+        cJSON *status = cJSON_GetObjectItemCaseSensitive(json, "status");
+        CHECK(cJSON_IsString(status) &&
+              strcmp(status->valuestring, "takendown") == 0);
+        cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+done:
+    free(mallory);
+    free(victim);
+    if (client) wf_xrpc_client_free(client);
+    metalbear_server_free(server);
+    rmtree(directory);
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("test_takedown: OK\n");
+    return 0;
+}

--- a/tools/firehose_probe.py
+++ b/tools/firehose_probe.py
@@ -11,7 +11,12 @@ strict reader (the Go ipld stack a relay runs) applies:
     (the multibase identity prefix)
   - the frame header names a known $type / op
 
-Usage: firehose_probe.py <host> [seconds]
+Usage: firehose_probe.py <host> [seconds] [cursor]
+
+A quiet host publishes nothing while the probe is attached and the run ends
+INCONCLUSIVE, which is indistinguishable from a host whose frames never
+decode. Pass a cursor to replay from a known sequence number instead — every
+frame the host has ever written is checked the same way a live one is.
 """
 import base64
 import os
@@ -25,6 +30,9 @@ import time
 host = sys.argv[1] if len(sys.argv) > 1 else "bear.croft.click"
 budget = float(sys.argv[2]) if len(sys.argv) > 2 else 30.0
 path = "/xrpc/com.atproto.sync.subscribeRepos"
+if len(sys.argv) > 3:
+    path += "?cursor=" + sys.argv[3]
+
 
 
 def connect(host, path):


### PR DESCRIPTION
Closes the two compatibility gaps the README's **Status** section named first.

## Takedowns were recorded and never consulted

`com.atproto.admin.updateSubjectStatus` wrote a row and nothing read it. An
account could be taken down and carry on serving its repository, answering its
handle and issuing sessions; the only statuses the host ever reported were
`deactivated` and `deleted`.

Two defects in the storage layer had to go first. A subject was required to
populate exactly one of `did`, `uri` and `blob_cid`, but a blob is only
identifiable as a pair — a CID names content, so two accounts storing identical
bytes share one — and passing both made the store reject the call, which nothing
checked, so **every blob takedown was silently discarded**. The lookup had the
mirror-image fault: a row written for an account's blob carries the DID too, so
a query about the account found it and reported **the whole repository taken
down on the strength of one moderated image**.

On top of that, the model itself:

- the status every endpoint reports, takedown outranking deactivation, matching
  the reference's `formatAccountStatus`
- sync reads refuse with `RepoTakendown`, deliberately distinct from
  `RepoDeactivated` — one is this host refusing to serve, the other the account
  holder's own choice, and a relay decides whether to come back on that difference
- taken-down records and blobs are withheld, and the blob cannot be re-uploaded
  to undo the takedown. Nothing is erased: a record stays in the repository,
  because removing it would rewrite history and break the commit chain
- applying a takedown revokes every session the account holds, refuses new
  logins with `AccountTakedown`, stops the handle resolving, and announces
  `takendown` on the firehose
- `getSubjectStatus` gains the shape its lexicon defines — `takedown` and
  `deactivated` always present rather than omitted when not applied, a blob
  subject requiring the DID that scopes it, and the record subject carrying the
  `cid` that makes it a strong reference

## listRepos paged on a row offset

Both `listRepos` and `listReposByCollection` resumed from an integer offset over
a list ordered by handle — neither a stable order (handles change) nor a usable
resume point. An account created or deleted mid-walk shifted every unread row:
the one moving into a slot already returned was never seen, the one moving out
was returned twice. A relay backfilling a host is exactly the client that walks
every page. They now resume from the last DID returned.

## Verification

- 13/13 `ctest` from a clean build tree, including the new `test_takedown` suite
  and a `listRepos` walk that creates an account mid-pagination and asserts no
  DID is repeated or lost
- exercised against the real daemon over HTTP, not just the in-process test
  server: takedown → `RepoTakendown` from getRepo/getLatestCommit/listBlobs,
  `AccountTakedown` on login, the pre-existing token dead, `HandleNotFound`,
  `takendown` in getRepoStatus/listRepos/getSubjectStatus, and the `#account`
  event on the log — then all of it restored on lifting
- `tools/firehose_probe.py bear1.croft.click 20 1` against the live dev host:
  341 frames, 6712 CID links, 0 malformed. The probe gained a cursor argument
  because a quiet host otherwise reports INCONCLUSIVE, which reads the same as a
  host whose frames never decode — the one failure it exists to catch

The dev instance at `/Volumes/Storage/Server/bear` builds from the `main`
checkout, so it is still running the previous build; it is worth a redeploy once
this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lahd4tPa1cWFhQB4YXPvwH