### PR TITLE
Close the remaining Status gaps: firehose purging, DNS breadth, metrics and logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(WOLFRAM_BUILD_CPP OFF CACHE BOOL "" FORCE)
 add_subdirectory("${WOLFRAM_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/wolfram")
 get_target_property(METALBEAR_CJSON_SOURCE_DIR cjson SOURCE_DIR)
 
-add_library(metalbear_core src/config_file.c src/handle_dns.c src/account.c src/account_registry.c src/account_context.c src/account_cache.c src/auth.c src/backup.c src/email.c src/oauth.c src/oauth_routes.c src/key_rotation.c src/repo_store.c src/sequencer.c src/server.c src/report.c src/blob_store.c src/blob_store_server.c)
+add_library(metalbear_core src/config_file.c src/log.c src/metrics.c src/handle_dns.c src/account.c src/account_registry.c src/account_context.c src/account_cache.c src/auth.c src/backup.c src/email.c src/oauth.c src/oauth_routes.c src/key_rotation.c src/repo_store.c src/sequencer.c src/server.c src/report.c src/blob_store.c src/blob_store_server.c)
 target_include_directories(metalbear_core PUBLIC include
     PUBLIC "${METALBEAR_CJSON_SOURCE_DIR}")
 target_link_libraries(metalbear_core PUBLIC wolfram cjson PRIVATE SQLite3::SQLite3 Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(WOLFRAM_BUILD_CPP OFF CACHE BOOL "" FORCE)
 add_subdirectory("${WOLFRAM_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/wolfram")
 get_target_property(METALBEAR_CJSON_SOURCE_DIR cjson SOURCE_DIR)
 
-add_library(metalbear_core src/config_file.c src/log.c src/metrics.c src/handle_dns.c src/account.c src/account_registry.c src/account_context.c src/account_cache.c src/auth.c src/backup.c src/email.c src/oauth.c src/oauth_routes.c src/key_rotation.c src/repo_store.c src/sequencer.c src/server.c src/report.c src/blob_store.c src/blob_store_server.c)
+add_library(metalbear_core src/config_file.c src/log.c src/metrics.c src/handle_dns.c src/handle_dns_rfc2136.c src/account.c src/account_registry.c src/account_context.c src/account_cache.c src/auth.c src/backup.c src/email.c src/oauth.c src/oauth_routes.c src/key_rotation.c src/repo_store.c src/sequencer.c src/server.c src/report.c src/blob_store.c src/blob_store_server.c)
 target_include_directories(metalbear_core PUBLIC include
     PUBLIC "${METALBEAR_CJSON_SOURCE_DIR}")
 target_link_libraries(metalbear_core PUBLIC wolfram cjson PRIVATE SQLite3::SQLite3 Threads::Threads)
@@ -104,6 +104,15 @@ if(METALBEAR_BUILD_TESTS)
     target_include_directories(test_metalbear_handle_dns PRIVATE
         "${METALBEAR_CJSON_SOURCE_DIR}" ${MICROHTTPD_INCLUDE_DIR})
     add_test(NAME metalbear_handle_dns COMMAND test_metalbear_handle_dns)
+
+    add_executable(test_metalbear_handle_dns_rfc2136
+        test/test_handle_dns_rfc2136.c)
+    target_link_libraries(test_metalbear_handle_dns_rfc2136 PRIVATE
+        metalbear_core Threads::Threads)
+    target_include_directories(test_metalbear_handle_dns_rfc2136 PRIVATE
+        "${METALBEAR_CJSON_SOURCE_DIR}")
+    add_test(NAME metalbear_handle_dns_rfc2136
+        COMMAND test_metalbear_handle_dns_rfc2136)
 
     add_executable(test_metalbear_backup test/test_backup.c)
     target_link_libraries(test_metalbear_backup PRIVATE metalbear_core SQLite3::SQLite3)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,41 @@ The `pdsadmin/metalbear-admin.sh` script mirrors the reference PDS admin tooling
 - Automatic firehose event retention
 - Dynamic landing page at `/` listing hosted accounts and version
 
+### Metrics
+
+`GET /metrics` serves the Prometheus text format, behind the same HTTP Basic
+admin credential as the `com.atproto.admin` endpoints — an open endpoint would
+publish a private host's account count and write rate to anyone who asked.
+
+```yaml
+scrape_configs:
+  - job_name: metalbear
+    basic_auth: { username: admin, password: "..." }
+    static_configs:
+      - targets: ["127.0.0.1:2583"]
+```
+
+Counters cover requests and refusals, accounts created and deleted, sessions
+and login failures, commits sequenced, blobs stored, takedowns applied,
+firehose subscribes and disconnects, and DNS and `requestCrawl` failures.
+Gauges report account counts by status, uptime, and the current firehose
+sequence number.
+
+`metalbear_firehose_seq` is the one worth alerting on. A PDS whose sequence has
+stopped advancing while accounts are still writing is indistinguishable, from
+outside, from a PDS that is down.
+
+### Logging
+
+`METALBEAR_LOG_LEVEL` is `debug`, `info` (default), `warn` or `error`, and
+`METALBEAR_LOG_FILE` a path to append to instead of stderr.
+
+`METALBEAR_LOG_FORMAT=json` emits one JSON object per line — `time`, `level`,
+`service`, `message` — for a collector to parse. Anything else keeps the
+human-readable form, which is what a person watching a terminal wants. The
+daemon's own startup and shutdown messages go through the same path, so a JSON
+stream stays parseable even when the server refuses to start.
+
 ## Install
 
 ### Container
@@ -454,11 +489,12 @@ PLC directory, and its posts, profile and media appear on the Bluesky AppView.
 
 Still missing or unproven for production use:
 
-- account deletion does not purge that DID's earlier firehose events
-- no metrics or structured operational logging
-- automatic `_atproto` record publication is implemented for Cloudflare only;
-  on any other DNS provider the operator writes one TXT record per account by
-  hand, or handles never resolve
+- request metrics are counted at the auth callback, so they cover every XRPC
+  route but not the plain HTTP ones, and carry no per-endpoint or per-status
+  breakdown
+- automatic `_atproto` record publication covers Cloudflare, DigitalOcean and
+  deSEC; on any other DNS provider the operator writes one TXT record per
+  account by hand, or handles never resolve
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -319,12 +319,27 @@ moved on a handle change, removed on deletion.
 provider  = "cloudflare"
 api_token = "..."   # Zone.DNS:Edit on the zone below
 zone_id   = "..."
+ttl       = 300
 ```
+
+Three providers are supported. `zone_id` is whatever each uses to name the
+zone, and `api_token` a credential that may edit its records:
+
+| `provider` | `zone_id` | `api_token` | Minimum TTL |
+| --- | --- | --- | --- |
+| `cloudflare` | the zone id from the dashboard | API token with `Zone.DNS:Edit` | 60 |
+| `digitalocean` | the domain, e.g. `example.com` | personal access token, write scope | 30 |
+| `desec` | the domain, e.g. `example.com` | account token | 3600 |
+
+A `ttl` below the provider's floor is raised to it rather than refused: failing
+every write over a number the provider dislikes would take handle resolution
+down for the whole host.
 
 Omit the section and handle resolution stays entirely the operator's business.
 A provider named without credentials is refused at startup rather than accepted:
 a host that mints accounts and silently writes no records is only discovered
-when every handle shows as `handle.invalid`, long after the accounts exist.
+when every handle shows as `handle.invalid`, long after the accounts exist. So
+is a provider name that is not one of the three, for the same reason.
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ zone_id   = "..."
 ttl       = 300
 ```
 
-Three providers are supported. `zone_id` is whatever each uses to name the
+Four providers are supported. `zone_id` is whatever each uses to name the
 zone, and `api_token` a credential that may edit its records:
 
 | `provider` | `zone_id` | `api_token` | Minimum TTL |
@@ -365,6 +365,29 @@ zone, and `api_token` a credential that may edit its records:
 | `cloudflare` | the zone id from the dashboard | API token with `Zone.DNS:Edit` | 60 |
 | `digitalocean` | the domain, e.g. `example.com` | personal access token, write scope | 30 |
 | `desec` | the domain, e.g. `example.com` | account token | 3600 |
+| `rfc2136` | the zone, e.g. `example.com` | TSIG key as `<name>:<base64 secret>` | 1 |
+
+`rfc2136` is the one that is not a vendor. It speaks the dynamic-update
+protocol (RFC 2136, signed per RFC 8945) that the nameservers themselves
+implement, so it covers BIND, Knot, PowerDNS, NSD and anything else
+standards-compliant — including a nameserver you run. It needs one extra
+setting, the server to send updates to:
+
+```toml
+[dns]
+provider  = "rfc2136"
+server    = "ns1.example.com"   # or "ns1.example.com:5353"
+zone_id   = "example.com"
+api_token = "metalbear-key:c2VjcmV0..."
+```
+
+The credential is the same key name and base64 secret that `nsupdate -y`,
+certbot's rfc2136 plugin and a BIND `key` stanza all take. Updates go over TCP
+and are TSIG-signed; the corresponding grant in BIND looks like
+
+```
+update-policy { grant metalbear-key name _atproto.*.example.com. TXT; };
+```
 
 A `ttl` below the provider's floor is raised to it rather than refused: failing
 every write over a number the provider dislikes would take handle resolution
@@ -489,12 +512,9 @@ PLC directory, and its posts, profile and media appear on the Bluesky AppView.
 
 Still missing or unproven for production use:
 
-- request metrics are counted at the auth callback, so they cover every XRPC
-  route but not the plain HTTP ones, and carry no per-endpoint or per-status
-  breakdown
-- automatic `_atproto` record publication covers Cloudflare, DigitalOcean and
-  deSEC; on any other DNS provider the operator writes one TXT record per
-  account by hand, or handles never resolve
+- the per-route metric table is bounded at 128 routes, after which traffic is
+  counted under `other` rather than by name — enough for the protocol surface,
+  but a host proxying a large AppView surface will spill
 
 ## Frontend
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -105,7 +105,7 @@ did = "did:web:api.bsky.app"
 # out and handle resolution stays entirely the operator's business, which is
 # what every deployment did before this existed.
 #
-# provider  = "cloudflare"   # cloudflare | digitalocean | desec
+# provider  = "cloudflare"   # cloudflare | digitalocean | desec | rfc2136
 # api_token = "..."          # a credential that may edit the zone's records
 # zone_id   = "..."          # cloudflare: the zone id; others: the domain
 # ttl       = 300            # short: a stale record shows a renamed handle
@@ -119,6 +119,14 @@ did = "did:web:api.bsky.app"
 # Each provider enforces its own minimum TTL — 60, 30 and 3600 respectively —
 # and a smaller value here is raised to it rather than refused, since failing
 # every write would take handle resolution down for the whole host.
+#
+# rfc2136 is not a vendor: it speaks the dynamic-update protocol the
+# nameservers themselves implement, so it works against BIND, Knot, PowerDNS,
+# NSD and anything else standards-compliant. It needs `server` as well, and its
+# api_token is the TSIG key as "<name>:<base64 secret>" — the same pair
+# nsupdate -y and a BIND key stanza take.
+#
+# server    = "ns1.example.com"       # or "ns1.example.com:5353"
 
 # [smtp]
 # host         = "smtp.example.com"

--- a/config.example.toml
+++ b/config.example.toml
@@ -105,10 +105,20 @@ did = "did:web:api.bsky.app"
 # out and handle resolution stays entirely the operator's business, which is
 # what every deployment did before this existed.
 #
-# provider  = "cloudflare"   # the only one implemented
-# api_token = "..."          # needs Zone.DNS:Edit on the zone below
-# zone_id   = "..."          # Cloudflare dashboard, zone overview
+# provider  = "cloudflare"   # cloudflare | digitalocean | desec
+# api_token = "..."          # a credential that may edit the zone's records
+# zone_id   = "..."          # cloudflare: the zone id; others: the domain
 # ttl       = 300            # short: a stale record shows a renamed handle
+#
+# zone_id is whatever the provider uses to name the zone: Cloudflare's opaque
+# id from the dashboard's zone overview, or the domain itself ("example.com")
+# for DigitalOcean and deSEC. api_token is a Cloudflare API token with
+# Zone.DNS:Edit, a DigitalOcean personal access token with write scope, or a
+# deSEC account token.
+#
+# Each provider enforces its own minimum TTL — 60, 30 and 3600 respectively —
+# and a smaller value here is raised to it rather than refused, since failing
+# every write would take handle resolution down for the whole host.
 
 # [smtp]
 # host         = "smtp.example.com"

--- a/include/metalbear/handle_dns.h
+++ b/include/metalbear/handle_dns.h
@@ -28,16 +28,22 @@ extern "C" {
 typedef struct metalbear_handle_dns metalbear_handle_dns;
 
 /*
- * Open a publisher. `provider` is "cloudflare" (the only one implemented) or
+ * Open a publisher. `provider` is "cloudflare", "digitalocean" or "desec", or
  * NULL/empty for none.
+ *
+ * `zone_id` is whatever the provider uses to name the zone: Cloudflare's
+ * opaque zone id, or the domain name itself for the other two.
  *
  * Returns WF_OK with *out == NULL when no provider is configured — an absent
  * publisher is the normal case, not a failure. A provider named but missing
  * its credentials is an error, because it means an operator asked for
  * something that will silently not happen.
  *
- * `ttl` of 0 uses the provider default. Short values are better here: a handle
- * changes when a person renames, and a stale record shows the old one.
+ * `ttl` of 0 uses the default. Short values are better here: a handle changes
+ * when a person renames, and a stale record shows the old one. A value below
+ * the provider's own floor is raised to it rather than refused — failing every
+ * write over a number the provider dislikes would take the whole host's handle
+ * resolution down.
  */
 wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
                                     const char *zone_id, int ttl,

--- a/include/metalbear/handle_dns.h
+++ b/include/metalbear/handle_dns.h
@@ -28,8 +28,8 @@ extern "C" {
 typedef struct metalbear_handle_dns metalbear_handle_dns;
 
 /*
- * Open a publisher. `provider` is "cloudflare", "digitalocean" or "desec", or
- * NULL/empty for none.
+ * Open a publisher. `provider` is "cloudflare", "digitalocean", "desec" or
+ * "rfc2136", or NULL/empty for none.
  *
  * `zone_id` is whatever the provider uses to name the zone: Cloudflare's
  * opaque zone id, or the domain name itself for the other two.
@@ -48,6 +48,20 @@ typedef struct metalbear_handle_dns metalbear_handle_dns;
 wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
                                     const char *zone_id, int ttl,
                                     metalbear_handle_dns **out);
+
+/*
+ * As above, with the nameserver the `rfc2136` provider updates — `host` or
+ * `host:port`. The HTTP providers ignore it; rfc2136 refuses to open without
+ * it, since it has nowhere else to learn where to send an update.
+ *
+ * For rfc2136 `api_token` is the TSIG key as `<name>:<base64 secret>`, the
+ * form nsupdate, certbot and a BIND key stanza all write.
+ */
+wf_status metalbear_handle_dns_open_ex(const char *provider,
+                                       const char *api_token,
+                                       const char *zone_id,
+                                       const char *server, int ttl,
+                                       metalbear_handle_dns **out);
 
 void metalbear_handle_dns_free(metalbear_handle_dns *dns);
 

--- a/include/metalbear/handle_dns_rfc2136.h
+++ b/include/metalbear/handle_dns_rfc2136.h
@@ -1,0 +1,64 @@
+#ifndef METALBEAR_HANDLE_DNS_RFC2136_H
+#define METALBEAR_HANDLE_DNS_RFC2136_H
+
+/*
+ * handle_dns_rfc2136.h — TSIG-signed dynamic DNS update.
+ *
+ * The other providers speak one vendor's HTTP API each. This one speaks the
+ * protocol the DNS servers themselves implement (RFC 2136, signed per RFC
+ * 8945), so it covers BIND, Knot, PowerDNS, NSD and anything else
+ * standards-compliant — which is the difference between "your provider is
+ * supported" and "your provider is supported if we wrote code for it".
+ *
+ * Kept separate from handle_dns.c because none of it is HTTP: message
+ * construction, HMAC signing and a TCP exchange have nothing in common with
+ * the REST providers beyond the interface they are reached through.
+ */
+
+#include "wolfram/xrpc.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct metalbear_rfc2136_config {
+    const char *server;     /* address of the authoritative server */
+    const char *port;       /* "53" unless the operator says otherwise */
+    const char *zone;       /* the zone being updated */
+    const char *key_name;   /* TSIG key name, as the server knows it */
+    const unsigned char *secret;
+    size_t secret_len;      /* the decoded key, not its base64 */
+} metalbear_rfc2136_config;
+
+/*
+ * Read the current TXT at `name`.
+ *
+ * A missing record is WF_OK with *out_found false, not an error: it is what
+ * every first account on a zone looks like, and treating it as a failure
+ * would stop the record ever being written.
+ */
+wf_status metalbear_rfc2136_query_txt(const metalbear_rfc2136_config *config,
+                                      const char *name, char *out,
+                                      size_t out_len, bool *out_found,
+                                      char *error, size_t error_len);
+
+/*
+ * Replace the TXT RRset at `name` with `value`, or remove it when `value` is
+ * NULL.
+ *
+ * One message carries both the delete and the add, so the name never appears
+ * without a record to a reader watching in between.
+ */
+wf_status metalbear_rfc2136_update_txt(const metalbear_rfc2136_config *config,
+                                       const char *name, const char *value,
+                                       int ttl, char *error,
+                                       size_t error_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metalbear/log.h
+++ b/include/metalbear/log.h
@@ -1,0 +1,55 @@
+#ifndef METALBEAR_LOG_H
+#define METALBEAR_LOG_H
+
+/*
+ * log.h — the process's log, in one of two formats.
+ *
+ * `METALBEAR_LOG_FORMAT=json` emits one JSON object per line for a collector
+ * to parse; anything else keeps the human-readable form, which is what a
+ * person watching a terminal wants and so stays the default.
+ *
+ * Everything that writes a log line goes through here, including the daemon's
+ * own startup and shutdown messages: a single fprintf to stderr alongside a
+ * JSON stream produces a line no parser accepts, and the operator loses
+ * exactly the message that says why the server would not start.
+ *
+ * `METALBEAR_LOG_LEVEL` is debug/info/warn/error (or 0-3), and
+ * `METALBEAR_LOG_FILE` a path to append to instead of stderr.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum metalbear_log_level {
+    METALBEAR_LOG_DEBUG = 0,
+    METALBEAR_LOG_INFO,
+    METALBEAR_LOG_WARN,
+    METALBEAR_LOG_ERROR,
+} metalbear_log_level;
+
+/* Read METALBEAR_LOG_LEVEL / _FORMAT / _FILE. Safe to call more than once;
+ * the server calls it at startup and the daemon before that, so a failure to
+ * start is reported in the format the operator configured. */
+void metalbear_log_configure(void);
+
+void metalbear_log(metalbear_log_level level, const char *fmt, ...)
+#if defined(__GNUC__)
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
+
+/* Close a configured log file. The next line falls back to stderr, so a
+ * caller that logs after this still gets its message somewhere. */
+void metalbear_log_close(void);
+
+#define LOG_DEBUG(...) metalbear_log(METALBEAR_LOG_DEBUG, __VA_ARGS__)
+#define LOG_INFO(...)  metalbear_log(METALBEAR_LOG_INFO, __VA_ARGS__)
+#define LOG_WARN(...)  metalbear_log(METALBEAR_LOG_WARN, __VA_ARGS__)
+#define LOG_ERROR(...) metalbear_log(METALBEAR_LOG_ERROR, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metalbear/metrics.h
+++ b/include/metalbear/metrics.h
@@ -1,0 +1,71 @@
+#ifndef METALBEAR_METRICS_H
+#define METALBEAR_METRICS_H
+
+/*
+ * metrics.h — process-wide counters, exposed at `GET /metrics` in the
+ * Prometheus text format.
+ *
+ * Only counters live here: values that start at zero and never go down, so a
+ * scrape that is missed loses resolution rather than information. Everything
+ * that describes the host's current state — how many accounts it holds, where
+ * the firehose has got to — is read from the real thing at scrape time instead
+ * of being mirrored here, because a mirrored gauge is a second copy of the
+ * truth and drifts from the first.
+ *
+ * Counters are atomic and lock-free. They are written on the request path, and
+ * a metric that could contend with a commit being signed would be worth less
+ * than it costs.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum metalbear_metric {
+    /* Every XRPC request that reached the auth callback, which is all of them
+     * except the plain HTTP routes. */
+    METALBEAR_METRIC_XRPC_REQUESTS = 0,
+    /* Requests refused before a handler ran: no token, a bad one, the wrong
+     * scope, or an account that may not act. A rate of these against the
+     * total is the first sign of a misconfigured client or a credential
+     * stuffing run. */
+    METALBEAR_METRIC_XRPC_REJECTED,
+    METALBEAR_METRIC_ACCOUNTS_CREATED,
+    METALBEAR_METRIC_ACCOUNTS_DELETED,
+    METALBEAR_METRIC_SESSIONS_CREATED,
+    METALBEAR_METRIC_LOGIN_FAILURES,
+    METALBEAR_METRIC_COMMITS_SEQUENCED,
+    METALBEAR_METRIC_BLOBS_UPLOADED,
+    METALBEAR_METRIC_TAKEDOWNS_APPLIED,
+    /* A firehose subscriber that connected, and one that went away. The
+     * difference is the number attached now; both are counters so a
+     * connection storm is still visible after it ends. */
+    METALBEAR_METRIC_FIREHOSE_SUBSCRIBES,
+    METALBEAR_METRIC_FIREHOSE_DISCONNECTS,
+    /* A DNS record that could not be written. Silent failure here is what
+     * leaves every handle showing as handle.invalid. */
+    METALBEAR_METRIC_DNS_FAILURES,
+    /* A relay that could not be told there was new data. */
+    METALBEAR_METRIC_CRAWL_FAILURES,
+    METALBEAR_METRIC_COUNT
+} metalbear_metric;
+
+void metalbear_metrics_inc(metalbear_metric metric);
+uint64_t metalbear_metrics_get(metalbear_metric metric);
+
+/* The metric's Prometheus name, without the `metalbear_` prefix, and its HELP
+ * text. Both are static strings; NULL for an out-of-range metric. */
+const char *metalbear_metric_name(metalbear_metric metric);
+const char *metalbear_metric_help(metalbear_metric metric);
+
+/* Reset every counter. For tests; a running server never calls it, since a
+ * counter that can go down breaks every rate() over it. */
+void metalbear_metrics_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/metalbear/metrics.h
+++ b/include/metalbear/metrics.h
@@ -24,14 +24,16 @@ extern "C" {
 #endif
 
 typedef enum metalbear_metric {
-    /* Every XRPC request that reached the auth callback, which is all of them
-     * except the plain HTTP routes. */
-    METALBEAR_METRIC_XRPC_REQUESTS = 0,
-    /* Requests refused before a handler ran: no token, a bad one, the wrong
-     * scope, or an account that may not act. A rate of these against the
-     * total is the first sign of a misconfigured client or a credential
-     * stuffing run. */
-    METALBEAR_METRIC_XRPC_REJECTED,
+    /* Every request the server finished, XRPC and plain HTTP alike, and
+     * those of them that answered 4xx or 5xx. */
+    METALBEAR_METRIC_REQUESTS = 0,
+    METALBEAR_METRIC_REQUESTS_FAILED,
+    /* Requests the auth callback refused: no token, a bad one, the wrong
+     * scope, or an account that may not act. Distinct from the 4xx count
+     * because the status alone does not say which of those it was, and a
+     * rate of these is the first sign of a misconfigured client or a
+     * credential-stuffing run. */
+    METALBEAR_METRIC_AUTH_REFUSED,
     METALBEAR_METRIC_ACCOUNTS_CREATED,
     METALBEAR_METRIC_ACCOUNTS_DELETED,
     METALBEAR_METRIC_SESSIONS_CREATED,
@@ -54,6 +56,38 @@ typedef enum metalbear_metric {
 
 void metalbear_metrics_inc(metalbear_metric metric);
 uint64_t metalbear_metrics_get(metalbear_metric metric);
+
+/*
+ * Per-route request accounting.
+ *
+ * A single total says a host is busy; it does not say which method is being
+ * hammered or which one started failing, and those are the two questions an
+ * operator actually has. Routes are recorded as they are seen rather than
+ * enumerated up front, because the set is not fixed — the AppView proxy
+ * forwards NSIDs this server has never heard of.
+ *
+ * The table is bounded. An unbounded label set is how a metrics endpoint
+ * becomes the thing that exhausts a host's memory, and an NSID arrives from
+ * the network. Requests beyond the bound are still counted, under the name
+ * `other`, so the totals stay honest.
+ */
+#define METALBEAR_METRICS_MAX_ROUTES 128
+
+/* Record one finished request. `nsid` may be NULL for a plain HTTP route, in
+ * which case `path` names it. */
+void metalbear_metrics_record_request(const char *nsid, const char *path,
+                                      unsigned int status);
+
+/*
+ * Visit each recorded route in turn. `requests` is the total seen, and
+ * `errors` those that answered 4xx or 5xx — the ratio being the thing worth
+ * alerting on, and cheaper to carry than a bucket per status code.
+ */
+typedef void (*metalbear_metrics_route_visitor)(void *ctx, const char *route,
+                                                uint64_t requests,
+                                                uint64_t errors);
+void metalbear_metrics_visit_routes(metalbear_metrics_route_visitor visit,
+                                    void *ctx);
 
 /* The metric's Prometheus name, without the `metalbear_` prefix, and its HELP
  * text. Both are static strings; NULL for an out-of-range metric. */

--- a/include/metalbear/sequencer.h
+++ b/include/metalbear/sequencer.h
@@ -80,6 +80,21 @@ wf_status metalbear_sequencer_retain(metalbear_sequencer *sequencer,
                                      int64_t max_age_seconds,
                                      int64_t min_events);
 
+/*
+ * Drop a deleted account's history from the log, keeping only its most recent
+ * event — which the caller must have just sequenced as the `deleted`
+ * #account announcement, since a consumer that never sees it cannot tell a
+ * deleted account from a host that went quiet.
+ *
+ * Without this, an account's commits and the record contents inside them stay
+ * on the wire for as long as retention holds them, and any consumer
+ * backfilling from an old cursor is handed the repository of somebody who
+ * asked to be gone. `out_removed` may be NULL.
+ */
+wf_status metalbear_sequencer_purge_account(metalbear_sequencer *sequencer,
+                                            const char *did,
+                                            int64_t *out_removed);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/metalbear/server.h
+++ b/include/metalbear/server.h
@@ -119,12 +119,18 @@ typedef struct metalbear_config {
      * route always can, but writing a record per account by hand does not scale
      * past the operator's own account.
      *
-     * `dns_provider` is "cloudflare" or empty. Empty leaves handle resolution
-     * to the operator, which is what every deployment did before this existed.
+     * `dns_provider` is "cloudflare", "digitalocean", "desec", "rfc2136", or
+     * empty. Empty leaves handle resolution to the operator, which is what
+     * every deployment did before this existed.
+     *
+     * `dns_server` is only read by the rfc2136 provider, which talks to a
+     * nameserver rather than to a vendor's API and so needs to be told which
+     * one. `host` or `host:port`.
      */
     const char *dns_provider;
     const char *dns_api_token;
     const char *dns_zone_id;
+    const char *dns_server;
     int64_t dns_record_ttl;
 } metalbear_config;
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -242,6 +242,7 @@ wf_status metalbear_config_file_load(const char *path,
         STR ("dns.provider",  dns_provider)
         STR ("dns.api_token", dns_api_token)
         STR ("dns.zone_id",   dns_zone_id)
+        STR ("dns.server",    dns_server)
         INT ("dns.ttl",       dns_record_ttl)
 
         STR ("smtp.host",         smtp_host)

--- a/src/handle_dns.c
+++ b/src/handle_dns.c
@@ -27,9 +27,11 @@
  */
 
 #include "metalbear/handle_dns.h"
+#include "metalbear/handle_dns_rfc2136.h"
 
 #include <cJSON.h>
 #include <curl/curl.h>
+#include <openssl/evp.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -48,6 +50,12 @@ struct metalbear_handle_dns {
     char *zone_id;
     int ttl;
     char last_error[256];
+    /* rfc2136 only: the nameserver to update, and the decoded TSIG key. */
+    char *server_host;
+    char *server_port;
+    char *key_name;
+    unsigned char *key_secret;
+    size_t key_secret_len;
 };
 
 /*
@@ -547,6 +555,125 @@ static wf_status desec_retract(metalbear_handle_dns *dns, const char *name,
 }
 
 /* ------------------------------------------------------------------ */
+/* RFC 2136                                                            */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Not an HTTP API at all: this speaks the update protocol the nameservers
+ * themselves implement, so one implementation covers BIND, Knot, PowerDNS,
+ * NSD and anything else standards-compliant. See handle_dns_rfc2136.c.
+ */
+static void rfc2136_config(metalbear_handle_dns *dns,
+                           metalbear_rfc2136_config *out) {
+    out->server = dns->server_host;
+    out->port = dns->server_port;
+    out->zone = dns->zone_id;
+    out->key_name = dns->key_name;
+    out->secret = dns->key_secret;
+    out->secret_len = dns->key_secret_len;
+}
+
+static wf_status rfc2136_lookup(metalbear_handle_dns *dns, const char *name,
+                                dns_record *out) {
+    metalbear_rfc2136_config config;
+    rfc2136_config(dns, &config);
+    char value[512];
+    bool found = false;
+    char error[256] = "";
+    wf_status st = metalbear_rfc2136_query_txt(&config, name, value,
+                                               sizeof(value), &found,
+                                               error, sizeof(error));
+    if (st != WF_OK) {
+        set_error(dns, "%s", error[0] ? error : "query failed");
+        return st;
+    }
+    if (found) {
+        out->found = true;
+        /* The wire form carries no quotes, so nothing to strip — but it goes
+         * through the same helper so every provider's content compares alike. */
+        out->content = unquote(value);
+        if (!out->content) return WF_ERR_ALLOC;
+    }
+    return WF_OK;
+}
+
+static wf_status rfc2136_publish(metalbear_handle_dns *dns, const char *name,
+                                 const char *content,
+                                 const dns_record *existing) {
+    (void)existing;   /* one message deletes the RRset and adds the new value */
+    metalbear_rfc2136_config config;
+    rfc2136_config(dns, &config);
+    char error[256] = "";
+    wf_status st = metalbear_rfc2136_update_txt(&config, name, content,
+                                                dns->ttl, error,
+                                                sizeof(error));
+    if (st != WF_OK) set_error(dns, "%s", error[0] ? error : "update failed");
+    return st;
+}
+
+static wf_status rfc2136_retract(metalbear_handle_dns *dns, const char *name,
+                                 const dns_record *existing) {
+    (void)existing;
+    metalbear_rfc2136_config config;
+    rfc2136_config(dns, &config);
+    char error[256] = "";
+    wf_status st = metalbear_rfc2136_update_txt(&config, name, NULL, dns->ttl,
+                                                error, sizeof(error));
+    if (st != WF_OK) set_error(dns, "%s", error[0] ? error : "update failed");
+    return st;
+}
+
+/*
+ * Split the credential into a TSIG key name and its secret.
+ *
+ * `<name>:<base64 secret>`, which is how every tool that speaks this protocol
+ * writes it — nsupdate's -y, certbot's rfc2136 plugin, and the key stanza in
+ * a BIND config all use the same pair.
+ */
+static bool parse_tsig_credential(metalbear_handle_dns *dns,
+                                  const char *credential) {
+    const char *colon = strchr(credential, ':');
+    if (!colon || colon == credential || !colon[1]) return false;
+    size_t name_len = (size_t)(colon - credential);
+    dns->key_name = malloc(name_len + 1);
+    if (!dns->key_name) return false;
+    memcpy(dns->key_name, credential, name_len);
+    dns->key_name[name_len] = '\0';
+
+    const char *b64 = colon + 1;
+    size_t b64_len = strlen(b64);
+    dns->key_secret = malloc(b64_len);      /* decoded is always shorter */
+    if (!dns->key_secret) return false;
+    int decoded = EVP_DecodeBlock(dns->key_secret,
+                                  (const unsigned char *)b64, (int)b64_len);
+    if (decoded <= 0) return false;
+    /* EVP_DecodeBlock pads to a multiple of three and counts the padding, so
+     * the trailing '=' have to be subtracted back off. A secret one byte too
+     * long produces a MAC the server rejects with no hint as to why. */
+    size_t len = (size_t)decoded;
+    for (size_t i = b64_len; i > 0 && b64[i - 1] == '='; i--) len--;
+    dns->key_secret_len = len;
+    return len > 0;
+}
+
+/* `host` or `host:port`, defaulting to the standard DNS port. */
+static bool parse_server(metalbear_handle_dns *dns, const char *server) {
+    const char *colon = strrchr(server, ':');
+    if (colon && colon != server && strchr(server, ':') == colon) {
+        size_t host_len = (size_t)(colon - server);
+        dns->server_host = malloc(host_len + 1);
+        if (!dns->server_host) return false;
+        memcpy(dns->server_host, server, host_len);
+        dns->server_host[host_len] = '\0';
+        dns->server_port = strdup(colon + 1);
+    } else {
+        dns->server_host = strdup(server);
+        dns->server_port = strdup("53");
+    }
+    return dns->server_host && dns->server_port;
+}
+
+/* ------------------------------------------------------------------ */
 
 static const dns_provider providers[] = {
     { "cloudflare", "https://api.cloudflare.com/client/v4", "Bearer", 60,
@@ -557,11 +684,23 @@ static const dns_provider providers[] = {
      * than serving a handle change slowly. */
     { "desec", "https://desec.io/api/v1", "Token", 3600,
       desec_lookup, desec_publish, desec_retract },
+    /* No API base and no auth scheme: this one is not HTTP. */
+    { "rfc2136", "", "", 1,
+      rfc2136_lookup, rfc2136_publish, rfc2136_retract },
 };
 
 wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
                                     const char *zone_id, int ttl,
                                     metalbear_handle_dns **out) {
+    return metalbear_handle_dns_open_ex(provider, api_token, zone_id, NULL,
+                                        ttl, out);
+}
+
+wf_status metalbear_handle_dns_open_ex(const char *provider,
+                                       const char *api_token,
+                                       const char *zone_id,
+                                       const char *server, int ttl,
+                                       metalbear_handle_dns **out) {
     if (!out) return WF_ERR_INVALID_ARG;
     *out = NULL;
 
@@ -594,6 +733,20 @@ wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
         metalbear_handle_dns_free(dns);
         return WF_ERR_ALLOC;
     }
+    /*
+     * rfc2136 needs a nameserver to talk to and a TSIG key to sign with, and
+     * neither has anywhere else to come from. Refused rather than defaulted:
+     * a host that mints accounts and silently writes no records is only found
+     * when every handle shows as handle.invalid.
+     */
+    if (strcmp(chosen->name, "rfc2136") == 0) {
+        if (!server || !server[0] ||
+            !parse_server(dns, server) ||
+            !parse_tsig_credential(dns, api_token)) {
+            metalbear_handle_dns_free(dns);
+            return WF_ERR_INVALID_ARG;
+        }
+    }
     *out = dns;
     return WF_OK;
 }
@@ -605,6 +758,15 @@ void metalbear_handle_dns_free(metalbear_handle_dns *dns) {
         memset(dns->api_token, 0, strlen(dns->api_token));
         free(dns->api_token);
     }
+    if (dns->key_secret) {
+        /* Cleared for the same reason as the API token: it authorises
+         * updates to the whole zone. */
+        memset(dns->key_secret, 0, dns->key_secret_len);
+        free(dns->key_secret);
+    }
+    free(dns->key_name);
+    free(dns->server_host);
+    free(dns->server_port);
     free(dns->zone_id);
     free(dns->api_base);
     free(dns);

--- a/src/handle_dns.c
+++ b/src/handle_dns.c
@@ -1,18 +1,29 @@
 #define _POSIX_C_SOURCE 200809L
 
 /*
- * handle_dns.c — Cloudflare-backed `_atproto` TXT record publishing.
+ * handle_dns.c — publish the `_atproto` TXT records that make handles resolve.
  *
- * Every operation goes through the zone's dns_records collection:
+ * Three providers are implemented behind one interface. They agree on what has
+ * to happen — read the record, write it if it differs, delete it when the
+ * account goes — and disagree about nearly everything else: how a record is
+ * addressed, whether TXT content is quoted, whether a record even has an
+ * identity of its own, and how a failure is reported.
  *
- *   GET    /zones/{zone}/dns_records?type=TXT&name=_atproto.<handle>
- *   POST   /zones/{zone}/dns_records
- *   PATCH  /zones/{zone}/dns_records/{id}
- *   DELETE /zones/{zone}/dns_records/{id}
+ *   cloudflare  Bearer token. Records are individually addressed by an opaque
+ *               id from a list query. A rejected-but-well-formed request comes
+ *               back 200 with `"success": false`, so the HTTP status alone
+ *               never tells you whether the record was written.
+ *   digitalocean
+ *               Bearer token. `zone_id` is the domain name. Record ids are
+ *               integers, and a delete answers 204 with no body at all.
+ *   desec       `Token` rather than `Bearer`. There are no individual records:
+ *               a name/type pair is one RRset replaced wholesale, TXT content
+ *               is stored quoted, absence is a 404 rather than an empty list,
+ *               and the minimum TTL is an hour.
  *
- * Reading before writing is what makes this idempotent. Creating blindly would
- * leave two TXT records at the same name on the second call, and a handle with
- * two conflicting DIDs resolves to neither.
+ * Reading before writing is what makes all three idempotent. Creating blindly
+ * would leave two TXT records at the same name on the second call, and a
+ * handle with two conflicting DIDs resolves to neither.
  */
 
 #include "metalbear/handle_dns.h"
@@ -20,20 +31,58 @@
 #include <cJSON.h>
 #include <curl/curl.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define CF_API "https://api.cloudflare.com/client/v4"
 #define DNS_TIMEOUT_SECONDS 15L
 #define DEFAULT_TTL 300
 
+typedef struct dns_provider dns_provider;
+
 struct metalbear_handle_dns {
+    const dns_provider *provider;
     char *api_base;
     char *api_token;
     char *zone_id;
     int ttl;
     char last_error[256];
+};
+
+/*
+ * A record as the provider describes it. `id` is the handle a later update or
+ * delete needs and is NULL where the provider has no such notion; `content` is
+ * the TXT value with any provider quoting already removed, so every caller
+ * compares the same thing.
+ */
+typedef struct dns_record {
+    char *id;
+    char *content;
+    bool found;
+} dns_record;
+
+static void dns_record_free(dns_record *rec) {
+    if (!rec) return;
+    free(rec->id);
+    free(rec->content);
+    rec->id = NULL;
+    rec->content = NULL;
+    rec->found = false;
+}
+
+struct dns_provider {
+    const char *name;
+    const char *api_base;
+    /* "Bearer" for the OAuth-style providers, "Token" for deSEC. */
+    const char *auth_scheme;
+    int min_ttl;
+    wf_status (*lookup)(metalbear_handle_dns *dns, const char *name,
+                        dns_record *out);
+    wf_status (*publish)(metalbear_handle_dns *dns, const char *name,
+                         const char *content, const dns_record *existing);
+    wf_status (*retract)(metalbear_handle_dns *dns, const char *name,
+                         const dns_record *existing);
 };
 
 typedef struct {
@@ -61,14 +110,19 @@ static void set_error(metalbear_handle_dns *dns, const char *fmt, ...) {
 }
 
 /*
- * One Cloudflare call. Returns the parsed body on a 2xx with `"success": true`,
- * NULL otherwise with last_error set.
+ * One HTTP call to the provider.
  *
- * Cloudflare answers 200 with `success: false` for some failures, so the HTTP
- * status alone is not enough to know whether the record was written.
+ * Returns the parsed body, or NULL — which is not on its own a failure, since
+ * a 204 carries none. `*out_status` is the HTTP status and is set whenever the
+ * request reached the server at all; `*out_ok` is false only when it did not.
+ * Interpreting the status is the provider's job, because they do not agree on
+ * what a failure looks like.
  */
-static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
-                      const char *url, const char *body) {
+static cJSON *http_call(metalbear_handle_dns *dns, const char *method,
+                        const char *url, const char *body,
+                        long *out_status, bool *out_ok) {
+    *out_status = 0;
+    *out_ok = false;
     CURL *curl = curl_easy_init();
     if (!curl) {
         set_error(dns, "could not initialise HTTP client");
@@ -76,7 +130,8 @@ static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
     }
 
     char auth[512];
-    snprintf(auth, sizeof(auth), "Authorization: Bearer %s", dns->api_token);
+    snprintf(auth, sizeof(auth), "Authorization: %s %s",
+             dns->provider->auth_scheme, dns->api_token);
     struct curl_slist *hdrs = curl_slist_append(NULL, auth);
     hdrs = curl_slist_append(hdrs, "Content-Type: application/json");
 
@@ -93,8 +148,7 @@ static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
     }
 
     CURLcode rc = curl_easy_perform(curl);
-    long status = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, out_status);
     curl_easy_cleanup(curl);
     curl_slist_free_all(hdrs);
 
@@ -103,20 +157,55 @@ static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
         free(out.data);
         return NULL;
     }
-
-    cJSON *doc = out.data ? cJSON_Parse(out.data) : NULL;
+    *out_ok = true;
+    cJSON *doc = out.data && out.data[0] ? cJSON_Parse(out.data) : NULL;
     free(out.data);
+    return doc;
+}
+
+/* Percent-encode one path or query component. Caller frees with curl_free. */
+static char *url_escape(const char *value) {
+    return curl_easy_escape(NULL, value, 0);
+}
+
+/* Copy `value` with one layer of surrounding double quotes removed, which is
+ * how deSEC (and any provider following the TXT presentation format) stores
+ * the content that Cloudflare returns bare. */
+static char *unquote(const char *value) {
+    if (!value) return NULL;
+    size_t len = strlen(value);
+    if (len >= 2 && value[0] == '"' && value[len - 1] == '"') {
+        char *out = malloc(len - 1);
+        if (!out) return NULL;
+        memcpy(out, value + 1, len - 2);
+        out[len - 2] = '\0';
+        return out;
+    }
+    return strdup(value);
+}
+
+/* ------------------------------------------------------------------ */
+/* Cloudflare                                                          */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Cloudflare answers 200 with `success: false` for a rejected but well-formed
+ * request, so the HTTP status alone never says whether the record was written.
+ * The reason lives in `errors[].message`, and carrying it through is the
+ * difference between "DNS failed" and "token lacks Zone.DNS:Edit" — which is
+ * the same log line an operator has to act on.
+ */
+static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
+                      const char *url, const char *body) {
+    long status = 0;
+    bool reached = false;
+    cJSON *doc = http_call(dns, method, url, body, &status, &reached);
+    if (!reached) return NULL;
     if (!doc) {
         set_error(dns, "%s: HTTP %ld with an unparseable body", method, status);
         return NULL;
     }
-
-    cJSON *success = cJSON_GetObjectItemCaseSensitive(doc, "success");
-    if (!cJSON_IsTrue(success)) {
-        /* Cloudflare reports what was wrong in `errors[].message`; carrying it
-         * through is the difference between "DNS failed" and "token lacks
-         * Zone.DNS:Edit", which is the same log line an operator has to act
-         * on. */
+    if (!cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(doc, "success"))) {
         const char *detail = NULL;
         cJSON *errors = cJSON_GetObjectItemCaseSensitive(doc, "errors");
         if (cJSON_IsArray(errors) && cJSON_GetArraySize(errors) > 0) {
@@ -132,6 +221,344 @@ static cJSON *cf_call(metalbear_handle_dns *dns, const char *method,
     return doc;
 }
 
+static wf_status cf_lookup(metalbear_handle_dns *dns, const char *name,
+                           dns_record *out) {
+    char *escaped = url_escape(name);
+    if (!escaped) return WF_ERR_ALLOC;
+    char url[768];
+    snprintf(url, sizeof(url), "%s/zones/%s/dns_records?type=TXT&name=%s",
+             dns->api_base, dns->zone_id, escaped);
+    curl_free(escaped);
+
+    cJSON *doc = cf_call(dns, "GET", url, NULL);
+    if (!doc) return WF_ERR_NETWORK;
+
+    wf_status st = WF_OK;
+    cJSON *result = cJSON_GetObjectItemCaseSensitive(doc, "result");
+    if (cJSON_IsArray(result) && cJSON_GetArraySize(result) > 0) {
+        cJSON *rec = cJSON_GetArrayItem(result, 0);
+        cJSON *id = cJSON_GetObjectItemCaseSensitive(rec, "id");
+        cJSON *content = cJSON_GetObjectItemCaseSensitive(rec, "content");
+        if (cJSON_IsString(id)) {
+            out->found = true;
+            out->id = strdup(id->valuestring);
+            if (!out->id) st = WF_ERR_ALLOC;
+            if (st == WF_OK && cJSON_IsString(content)) {
+                out->content = unquote(content->valuestring);
+                if (!out->content) st = WF_ERR_ALLOC;
+            }
+        }
+    }
+    cJSON_Delete(doc);
+    return st;
+}
+
+static wf_status cf_publish(metalbear_handle_dns *dns, const char *name,
+                            const char *content, const dns_record *existing) {
+    cJSON *body = cJSON_CreateObject();
+    if (!body) return WF_ERR_ALLOC;
+    cJSON_AddStringToObject(body, "type", "TXT");
+    cJSON_AddStringToObject(body, "name", name);
+    cJSON_AddStringToObject(body, "content", content);
+    cJSON_AddNumberToObject(body, "ttl", dns->ttl);
+    cJSON_AddStringToObject(body, "comment",
+                            "atproto handle, written by MetalBear");
+    char *json = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!json) return WF_ERR_ALLOC;
+
+    char url[768];
+    if (existing->found)
+        snprintf(url, sizeof(url), "%s/zones/%s/dns_records/%s", dns->api_base,
+                 dns->zone_id, existing->id);
+    else
+        snprintf(url, sizeof(url), "%s/zones/%s/dns_records", dns->api_base,
+                 dns->zone_id);
+
+    cJSON *doc = cf_call(dns, existing->found ? "PATCH" : "POST", url, json);
+    free(json);
+    if (!doc) return WF_ERR_NETWORK;
+    cJSON_Delete(doc);
+    return WF_OK;
+}
+
+static wf_status cf_retract(metalbear_handle_dns *dns, const char *name,
+                            const dns_record *existing) {
+    (void)name;
+    char url[768];
+    snprintf(url, sizeof(url), "%s/zones/%s/dns_records/%s", dns->api_base,
+             dns->zone_id, existing->id);
+    cJSON *doc = cf_call(dns, "DELETE", url, NULL);
+    if (!doc) return WF_ERR_NETWORK;
+    cJSON_Delete(doc);
+    return WF_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* DigitalOcean                                                        */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Status-driven, unlike Cloudflare: any 2xx succeeded. A delete answers 204
+ * with no body, so an absent document is not on its own an error here.
+ */
+static bool do_ok(metalbear_handle_dns *dns, const char *method, long status,
+                  cJSON *doc) {
+    if (status >= 200 && status < 300) return true;
+    const char *detail = NULL;
+    cJSON *msg = doc ? cJSON_GetObjectItemCaseSensitive(doc, "message") : NULL;
+    if (cJSON_IsString(msg)) detail = msg->valuestring;
+    set_error(dns, "%s: HTTP %ld: %s", method, status,
+              detail ? detail : "request rejected");
+    return false;
+}
+
+static wf_status do_lookup(metalbear_handle_dns *dns, const char *name,
+                           dns_record *out) {
+    char *escaped = url_escape(name);
+    if (!escaped) return WF_ERR_ALLOC;
+    char url[768];
+    snprintf(url, sizeof(url), "%s/domains/%s/records?type=TXT&name=%s",
+             dns->api_base, dns->zone_id, escaped);
+    curl_free(escaped);
+
+    long status = 0;
+    bool reached = false;
+    cJSON *doc = http_call(dns, "GET", url, NULL, &status, &reached);
+    if (!reached) return WF_ERR_NETWORK;
+    if (!do_ok(dns, "GET", status, doc)) {
+        cJSON_Delete(doc);
+        return WF_ERR_NETWORK;
+    }
+
+    wf_status st = WF_OK;
+    cJSON *records = cJSON_GetObjectItemCaseSensitive(doc, "domain_records");
+    if (cJSON_IsArray(records) && cJSON_GetArraySize(records) > 0) {
+        cJSON *rec = cJSON_GetArrayItem(records, 0);
+        cJSON *id = cJSON_GetObjectItemCaseSensitive(rec, "id");
+        cJSON *data = cJSON_GetObjectItemCaseSensitive(rec, "data");
+        /* Record ids are integers here, and are formatted back into the URL
+         * of the update and delete that follow. */
+        if (cJSON_IsNumber(id)) {
+            char id_buf[32];
+            snprintf(id_buf, sizeof(id_buf), "%lld",
+                     (long long)id->valuedouble);
+            out->found = true;
+            out->id = strdup(id_buf);
+            if (!out->id) st = WF_ERR_ALLOC;
+            if (st == WF_OK && cJSON_IsString(data)) {
+                out->content = unquote(data->valuestring);
+                if (!out->content) st = WF_ERR_ALLOC;
+            }
+        }
+    }
+    cJSON_Delete(doc);
+    return st;
+}
+
+static wf_status do_publish(metalbear_handle_dns *dns, const char *name,
+                            const char *content, const dns_record *existing) {
+    cJSON *body = cJSON_CreateObject();
+    if (!body) return WF_ERR_ALLOC;
+    cJSON_AddStringToObject(body, "type", "TXT");
+    /* Fully qualified, with the trailing dot that stops the API appending the
+     * domain to a name that already ends with it. */
+    char fqdn[512];
+    snprintf(fqdn, sizeof(fqdn), "%s.", name);
+    cJSON_AddStringToObject(body, "name", fqdn);
+    cJSON_AddStringToObject(body, "data", content);
+    cJSON_AddNumberToObject(body, "ttl", dns->ttl);
+    char *json = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!json) return WF_ERR_ALLOC;
+
+    char url[768];
+    if (existing->found)
+        snprintf(url, sizeof(url), "%s/domains/%s/records/%s", dns->api_base,
+                 dns->zone_id, existing->id);
+    else
+        snprintf(url, sizeof(url), "%s/domains/%s/records", dns->api_base,
+                 dns->zone_id);
+
+    long status = 0;
+    bool reached = false;
+    const char *method = existing->found ? "PUT" : "POST";
+    cJSON *doc = http_call(dns, method, url, json, &status, &reached);
+    free(json);
+    bool ok = reached && do_ok(dns, method, status, doc);
+    cJSON_Delete(doc);
+    return ok ? WF_OK : WF_ERR_NETWORK;
+}
+
+static wf_status do_retract(metalbear_handle_dns *dns, const char *name,
+                            const dns_record *existing) {
+    (void)name;
+    char url[768];
+    snprintf(url, sizeof(url), "%s/domains/%s/records/%s", dns->api_base,
+             dns->zone_id, existing->id);
+    long status = 0;
+    bool reached = false;
+    cJSON *doc = http_call(dns, "DELETE", url, NULL, &status, &reached);
+    bool ok = reached && do_ok(dns, "DELETE", status, doc);
+    cJSON_Delete(doc);
+    return ok ? WF_OK : WF_ERR_NETWORK;
+}
+
+/* ------------------------------------------------------------------ */
+/* deSEC                                                               */
+/* ------------------------------------------------------------------ */
+
+/*
+ * deSEC has no individual records: a name and type together are one RRset,
+ * replaced wholesale. That makes publishing a single PUT with no create/update
+ * distinction, and retracting a PUT of an empty record list.
+ *
+ * The RRset is addressed by `subname`, which is the record name relative to
+ * the domain — `_atproto.alice` under `example.com`, not the full name.
+ */
+static wf_status desec_subname(metalbear_handle_dns *dns, const char *name,
+                               char *out, size_t out_len) {
+    size_t name_len = strlen(name);
+    size_t zone_len = strlen(dns->zone_id);
+    if (name_len <= zone_len + 1 ||
+        strcmp(name + name_len - zone_len, dns->zone_id) != 0 ||
+        name[name_len - zone_len - 1] != '.') {
+        set_error(dns, "%s is not inside the configured domain %s", name,
+                  dns->zone_id);
+        return WF_ERR_INVALID_ARG;
+    }
+    size_t sub_len = name_len - zone_len - 1;
+    if (sub_len >= out_len) return WF_ERR_INVALID_ARG;
+    memcpy(out, name, sub_len);
+    out[sub_len] = '\0';
+    return WF_OK;
+}
+
+static bool desec_ok(metalbear_handle_dns *dns, const char *method,
+                     long status, cJSON *doc) {
+    if (status >= 200 && status < 300) return true;
+    const char *detail = NULL;
+    cJSON *msg = doc ? cJSON_GetObjectItemCaseSensitive(doc, "detail") : NULL;
+    if (cJSON_IsString(msg)) detail = msg->valuestring;
+    set_error(dns, "%s: HTTP %ld: %s", method, status,
+              detail ? detail : "request rejected");
+    return false;
+}
+
+static wf_status desec_lookup(metalbear_handle_dns *dns, const char *name,
+                              dns_record *out) {
+    char subname[512];
+    wf_status st = desec_subname(dns, name, subname, sizeof(subname));
+    if (st != WF_OK) return st;
+    char *escaped = url_escape(subname);
+    if (!escaped) return WF_ERR_ALLOC;
+    char url[768];
+    snprintf(url, sizeof(url), "%s/domains/%s/rrsets/%s/TXT/", dns->api_base,
+             dns->zone_id, escaped);
+    curl_free(escaped);
+
+    long status = 0;
+    bool reached = false;
+    cJSON *doc = http_call(dns, "GET", url, NULL, &status, &reached);
+    if (!reached) return WF_ERR_NETWORK;
+    /* Absence is a 404 here, not an empty list. */
+    if (status == 404) {
+        cJSON_Delete(doc);
+        return WF_OK;
+    }
+    if (!desec_ok(dns, "GET", status, doc)) {
+        cJSON_Delete(doc);
+        return WF_ERR_NETWORK;
+    }
+    cJSON *records = cJSON_GetObjectItemCaseSensitive(doc, "records");
+    if (cJSON_IsArray(records) && cJSON_GetArraySize(records) > 0) {
+        cJSON *first = cJSON_GetArrayItem(records, 0);
+        if (cJSON_IsString(first)) {
+            out->found = true;
+            out->content = unquote(first->valuestring);
+            if (!out->content) st = WF_ERR_ALLOC;
+        }
+    }
+    cJSON_Delete(doc);
+    return st;
+}
+
+/* Replace the RRset with `records` — one quoted value, or none to remove it. */
+static wf_status desec_put(metalbear_handle_dns *dns, const char *name,
+                           const char *content) {
+    char subname[512];
+    wf_status st = desec_subname(dns, name, subname, sizeof(subname));
+    if (st != WF_OK) return st;
+
+    cJSON *body = cJSON_CreateObject();
+    cJSON *records = cJSON_CreateArray();
+    if (!body || !records) {
+        cJSON_Delete(body);
+        cJSON_Delete(records);
+        return WF_ERR_ALLOC;
+    }
+    cJSON_AddStringToObject(body, "subname", subname);
+    cJSON_AddStringToObject(body, "type", "TXT");
+    cJSON_AddNumberToObject(body, "ttl", dns->ttl);
+    if (content) {
+        /* TXT content is stored in presentation format, quotes included. */
+        char quoted[512];
+        snprintf(quoted, sizeof(quoted), "\"%s\"", content);
+        cJSON_AddItemToArray(records, cJSON_CreateString(quoted));
+    }
+    cJSON_AddItemToObject(body, "records", records);
+    char *json = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!json) return WF_ERR_ALLOC;
+
+    char *escaped = url_escape(subname);
+    if (!escaped) {
+        free(json);
+        return WF_ERR_ALLOC;
+    }
+    char url[768];
+    snprintf(url, sizeof(url), "%s/domains/%s/rrsets/%s/TXT/", dns->api_base,
+             dns->zone_id, escaped);
+    curl_free(escaped);
+
+    long status = 0;
+    bool reached = false;
+    cJSON *doc = http_call(dns, "PUT", url, json, &status, &reached);
+    free(json);
+    /* Deleting an RRset that is not there answers 404, and the desired state
+     * — no record — already holds. */
+    bool ok = reached && (desec_ok(dns, "PUT", status, doc) ||
+                          (!content && status == 404));
+    cJSON_Delete(doc);
+    return ok ? WF_OK : WF_ERR_NETWORK;
+}
+
+static wf_status desec_publish(metalbear_handle_dns *dns, const char *name,
+                               const char *content,
+                               const dns_record *existing) {
+    (void)existing;
+    return desec_put(dns, name, content);
+}
+
+static wf_status desec_retract(metalbear_handle_dns *dns, const char *name,
+                               const dns_record *existing) {
+    (void)existing;
+    return desec_put(dns, name, NULL);
+}
+
+/* ------------------------------------------------------------------ */
+
+static const dns_provider providers[] = {
+    { "cloudflare", "https://api.cloudflare.com/client/v4", "Bearer", 60,
+      cf_lookup, cf_publish, cf_retract },
+    { "digitalocean", "https://api.digitalocean.com/v2", "Bearer", 30,
+      do_lookup, do_publish, do_retract },
+    /* deSEC refuses anything under an hour, and rejecting the write is worse
+     * than serving a handle change slowly. */
+    { "desec", "https://desec.io/api/v1", "Token", 3600,
+      desec_lookup, desec_publish, desec_retract },
+};
+
 wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
                                     const char *zone_id, int ttl,
                                     metalbear_handle_dns **out) {
@@ -139,7 +566,10 @@ wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
     *out = NULL;
 
     if (!provider || !provider[0]) return WF_OK;
-    if (strcmp(provider, "cloudflare") != 0) return WF_ERR_INVALID_ARG;
+    const dns_provider *chosen = NULL;
+    for (size_t i = 0; i < sizeof(providers) / sizeof(providers[0]); i++)
+        if (strcmp(provider, providers[i].name) == 0) chosen = &providers[i];
+    if (!chosen) return WF_ERR_INVALID_ARG;
 
     /* Half a credential is worse than none: the operator believes records are
      * being written and every handle silently fails to resolve. */
@@ -148,13 +578,18 @@ wf_status metalbear_handle_dns_open(const char *provider, const char *api_token,
 
     metalbear_handle_dns *dns = calloc(1, sizeof(*dns));
     if (!dns) return WF_ERR_ALLOC;
+    dns->provider = chosen;
     /* Overridable so the tests can point at a local stand-in for the API.
      * Nothing in a deployment should set it. */
     const char *base = getenv("METALBEAR_DNS_API_BASE");
-    dns->api_base = strdup(base && base[0] ? base : CF_API);
+    dns->api_base = strdup(base && base[0] ? base : chosen->api_base);
     dns->api_token = strdup(api_token);
     dns->zone_id = strdup(zone_id);
     dns->ttl = ttl > 0 ? ttl : DEFAULT_TTL;
+    /* Raised rather than refused: a provider's floor is its business, and
+     * failing every write over a configured value it dislikes would take the
+     * whole host's handle resolution down. */
+    if (dns->ttl < chosen->min_ttl) dns->ttl = chosen->min_ttl;
     if (!dns->api_base || !dns->api_token || !dns->zone_id) {
         metalbear_handle_dns_free(dns);
         return WF_ERR_ALLOC;
@@ -177,50 +612,6 @@ void metalbear_handle_dns_free(metalbear_handle_dns *dns) {
 
 const char *metalbear_handle_dns_last_error(const metalbear_handle_dns *dns) {
     return dns ? dns->last_error : "";
-}
-
-/*
- * Find the existing `_atproto.<handle>` TXT record.
- *
- * `found` distinguishes "no such record" from "could not ask", which the
- * callers need: the first means create it, the second means stop.
- */
-static wf_status lookup(metalbear_handle_dns *dns, const char *name,
-                        char **id_out, char **content_out, int *found) {
-    *found = 0;
-    if (id_out) *id_out = NULL;
-    if (content_out) *content_out = NULL;
-
-    char *escaped = curl_easy_escape(NULL, name, 0);
-    if (!escaped) return WF_ERR_ALLOC;
-    char url[768];
-    snprintf(url, sizeof(url), "%s/zones/%s/dns_records?type=TXT&name=%s",
-             dns->api_base, dns->zone_id, escaped);
-    curl_free(escaped);
-
-    cJSON *doc = cf_call(dns, "GET", url, NULL);
-    if (!doc) return WF_ERR_NETWORK;
-
-    wf_status st = WF_OK;
-    cJSON *result = cJSON_GetObjectItemCaseSensitive(doc, "result");
-    if (cJSON_IsArray(result) && cJSON_GetArraySize(result) > 0) {
-        cJSON *rec = cJSON_GetArrayItem(result, 0);
-        cJSON *id = cJSON_GetObjectItemCaseSensitive(rec, "id");
-        cJSON *content = cJSON_GetObjectItemCaseSensitive(rec, "content");
-        if (cJSON_IsString(id)) {
-            *found = 1;
-            if (id_out) {
-                *id_out = strdup(id->valuestring);
-                if (!*id_out) st = WF_ERR_ALLOC;
-            }
-            if (st == WF_OK && content_out && cJSON_IsString(content)) {
-                *content_out = strdup(content->valuestring);
-                if (!*content_out) st = WF_ERR_ALLOC;
-            }
-        }
-    }
-    cJSON_Delete(doc);
-    return st;
 }
 
 /* `_atproto.<handle>`, the name the resolver asks for. */
@@ -246,51 +637,22 @@ wf_status metalbear_handle_dns_publish(metalbear_handle_dns *dns,
     char want[512];
     snprintf(want, sizeof(want), "did=%s", did);
 
-    char *id = NULL, *have = NULL;
-    int found = 0;
-    st = lookup(dns, name, &id, &have, &found);
-    if (st != WF_OK) return st;
-
-    if (found && have && strcmp(have, want) == 0) {
+    dns_record existing = {0};
+    st = dns->provider->lookup(dns, name, &existing);
+    if (st != WF_OK) {
+        dns_record_free(&existing);
+        return st;
+    }
+    if (existing.found && existing.content &&
+        strcmp(existing.content, want) == 0) {
         /* Already correct. Re-writing it would churn the zone's history for
          * nothing on every restart-time reconciliation. */
-        free(id);
-        free(have);
+        dns_record_free(&existing);
         return WF_OK;
     }
-    free(have);
-
-    cJSON *body = cJSON_CreateObject();
-    if (!body) {
-        free(id);
-        return WF_ERR_ALLOC;
-    }
-    cJSON_AddStringToObject(body, "type", "TXT");
-    cJSON_AddStringToObject(body, "name", name);
-    cJSON_AddStringToObject(body, "content", want);
-    cJSON_AddNumberToObject(body, "ttl", dns->ttl);
-    cJSON_AddStringToObject(body, "comment", "atproto handle, written by MetalBear");
-    char *json = cJSON_PrintUnformatted(body);
-    cJSON_Delete(body);
-    if (!json) {
-        free(id);
-        return WF_ERR_ALLOC;
-    }
-
-    char url[768];
-    if (found)
-        snprintf(url, sizeof(url), "%s/zones/%s/dns_records/%s", dns->api_base,
-                 dns->zone_id, id);
-    else
-        snprintf(url, sizeof(url), "%s/zones/%s/dns_records", dns->api_base,
-                 dns->zone_id);
-
-    cJSON *doc = cf_call(dns, found ? "PATCH" : "POST", url, json);
-    free(json);
-    free(id);
-    if (!doc) return WF_ERR_NETWORK;
-    cJSON_Delete(doc);
-    return WF_OK;
+    st = dns->provider->publish(dns, name, want, &existing);
+    dns_record_free(&existing);
+    return st;
 }
 
 wf_status metalbear_handle_dns_retract(metalbear_handle_dns *dns,
@@ -302,19 +664,19 @@ wf_status metalbear_handle_dns_retract(metalbear_handle_dns *dns,
     wf_status st = record_name(handle, name, sizeof(name));
     if (st != WF_OK) return st;
 
-    char *id = NULL;
-    int found = 0;
-    st = lookup(dns, name, &id, NULL, &found);
-    if (st != WF_OK) return st;
-    if (!found) return WF_OK;
-
-    char url[768];
-    snprintf(url, sizeof(url), "%s/zones/%s/dns_records/%s", dns->api_base,
-             dns->zone_id, id);
-    free(id);
-
-    cJSON *doc = cf_call(dns, "DELETE", url, NULL);
-    if (!doc) return WF_ERR_NETWORK;
-    cJSON_Delete(doc);
-    return WF_OK;
+    dns_record existing = {0};
+    st = dns->provider->lookup(dns, name, &existing);
+    if (st != WF_OK) {
+        dns_record_free(&existing);
+        return st;
+    }
+    /* An absent record is the desired state already — including on deSEC,
+     * whose lookup reports a missing RRset as not found rather than empty. */
+    if (!existing.found) {
+        dns_record_free(&existing);
+        return WF_OK;
+    }
+    st = dns->provider->retract(dns, name, &existing);
+    dns_record_free(&existing);
+    return st;
 }

--- a/src/handle_dns_rfc2136.c
+++ b/src/handle_dns_rfc2136.c
@@ -27,6 +27,7 @@
 #include "metalbear/handle_dns_rfc2136.h"
 
 #include <openssl/hmac.h>
+#include <openssl/evp.h>
 
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -150,17 +151,21 @@ static bool tsig_sign(msg *m, const char *key_name,
     put_u16(&vars, 0);                       /* other len */
     if (vars.overflow || m->overflow) return false;
 
+    /*
+     * The digest input is the message followed by the variables, joined here
+     * rather than fed in through the incremental API: the one-shot HMAC is
+     * what the rest of this codebase uses, and the two buffers together are
+     * bounded by the message size.
+     */
+    unsigned char digest_input[sizeof(m->data) + sizeof(vars.data)];
+    memcpy(digest_input, m->data, m->len);
+    memcpy(digest_input + m->len, vars.data, vars.len);
+
     unsigned char mac[EVP_MAX_MD_SIZE];
     unsigned int mac_len = 0;
-    HMAC_CTX *ctx = HMAC_CTX_new();
-    if (!ctx) return false;
-    bool ok = HMAC_Init_ex(ctx, secret, (int)secret_len, EVP_sha256(),
-                           NULL) == 1 &&
-              HMAC_Update(ctx, m->data, m->len) == 1 &&
-              HMAC_Update(ctx, vars.data, vars.len) == 1 &&
-              HMAC_Final(ctx, mac, &mac_len) == 1;
-    HMAC_CTX_free(ctx);
-    if (!ok) return false;
+    if (!HMAC(EVP_sha256(), secret, (int)secret_len, digest_input,
+              m->len + vars.len, mac, &mac_len))
+        return false;
 
     put_name(m, key_name);
     put_u16(m, DNS_TYPE_TSIG);

--- a/src/handle_dns_rfc2136.c
+++ b/src/handle_dns_rfc2136.c
@@ -1,0 +1,480 @@
+#define _POSIX_C_SOURCE 200809L
+
+/*
+ * handle_dns_rfc2136.c — `_atproto` records over RFC 2136 dynamic update.
+ *
+ * The HTTP providers each speak their own API; this one speaks the protocol
+ * the DNS servers themselves implement, so it covers BIND, Knot, PowerDNS,
+ * NSD and anything else standards-compliant rather than one vendor. It is
+ * what `nsupdate` sends, minus the parts a PDS never needs.
+ *
+ * Two message kinds are built here:
+ *
+ *   a QUERY for the current TXT at `_atproto.<handle>`, so a record that
+ *   already says the right thing is left alone, and
+ *
+ *   an UPDATE (opcode 5) that deletes the existing RRset and adds the new
+ *   one. Delete-then-add in a single message is what makes the write atomic
+ *   and idempotent: adding alone would leave two TXT records at one name, and
+ *   a handle with two conflicting DIDs resolves to neither.
+ *
+ * Both are signed with TSIG (RFC 8945) and sent over TCP. TCP because an
+ * update is a write and must not be answered from a truncated UDP reply, and
+ * signed because an unauthenticated update is one anybody on the path can
+ * forge.
+ */
+
+#include "metalbear/handle_dns_rfc2136.h"
+
+#include <openssl/hmac.h>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#define DNS_TYPE_TXT   16
+#define DNS_TYPE_SOA    6
+#define DNS_TYPE_TSIG 250
+#define DNS_CLASS_IN    1
+#define DNS_CLASS_ANY 255
+#define DNS_OPCODE_UPDATE 5
+#define TSIG_FUDGE 300
+#define DNS_TIMEOUT_SECONDS 10
+
+/* A message under construction. Fixed size: an update naming one TXT record
+ * is a few hundred bytes, and a handle long enough to overflow this could not
+ * be a DNS name in the first place. */
+typedef struct msg {
+    unsigned char data[4096];
+    size_t len;
+    bool overflow;
+} msg;
+
+static void put_bytes(msg *m, const void *bytes, size_t n) {
+    if (m->overflow || m->len + n > sizeof(m->data)) {
+        m->overflow = true;
+        return;
+    }
+    memcpy(m->data + m->len, bytes, n);
+    m->len += n;
+}
+
+static void put_u8(msg *m, unsigned value) {
+    unsigned char b = (unsigned char)value;
+    put_bytes(m, &b, 1);
+}
+
+static void put_u16(msg *m, unsigned value) {
+    unsigned char b[2] = { (unsigned char)(value >> 8), (unsigned char)value };
+    put_bytes(m, b, 2);
+}
+
+static void put_u32(msg *m, unsigned long value) {
+    unsigned char b[4] = {
+        (unsigned char)(value >> 24), (unsigned char)(value >> 16),
+        (unsigned char)(value >> 8),  (unsigned char)value
+    };
+    put_bytes(m, b, 4);
+}
+
+/*
+ * A domain name in wire format: each label length-prefixed, terminated by a
+ * zero length. Never compressed — a pointer into the message would be
+ * meaningless in the TSIG digest, which covers some names outside the message
+ * body entirely.
+ */
+static void put_name(msg *m, const char *name) {
+    const char *p = name;
+    while (*p) {
+        const char *dot = strchr(p, '.');
+        size_t label = dot ? (size_t)(dot - p) : strlen(p);
+        if (label == 0) break;          /* trailing dot */
+        if (label > 63) { m->overflow = true; return; }
+        put_u8(m, (unsigned)label);
+        put_bytes(m, p, label);
+        if (!dot) break;
+        p = dot + 1;
+    }
+    put_u8(m, 0);
+}
+
+/* As put_name, but lower-cased: TSIG digests names in canonical form, and a
+ * key name the operator wrote in mixed case must still verify. */
+static void put_name_canonical(msg *m, const char *name) {
+    char lowered[256];
+    size_t i = 0;
+    for (; name[i] && i + 1 < sizeof(lowered); i++) {
+        char c = name[i];
+        lowered[i] = (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+    }
+    lowered[i] = '\0';
+    put_name(m, lowered);
+}
+
+/* ------------------------------------------------------------------ */
+/* TSIG                                                                */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Sign `m` in place: compute the MAC over the message so far plus the TSIG
+ * variables, append the TSIG RR, and bump ARCOUNT.
+ *
+ * The digest covers the message with ARCOUNT still excluding the TSIG record
+ * being added, which is why the count is incremented afterwards rather than
+ * before. Getting that backwards produces a signature the server rejects
+ * while everything here looks correct.
+ */
+static bool tsig_sign(msg *m, const char *key_name,
+                      const unsigned char *secret, size_t secret_len,
+                      unsigned original_id) {
+    const char *algorithm = "hmac-sha256";
+
+    msg vars = {0};
+    put_name_canonical(&vars, key_name);
+    put_u16(&vars, DNS_CLASS_ANY);
+    put_u32(&vars, 0);                       /* TTL */
+    put_name_canonical(&vars, algorithm);
+    time_t now = time(NULL);
+    put_u16(&vars, (unsigned)((uint64_t)now >> 32));   /* time signed, 48 bits */
+    put_u32(&vars, (unsigned long)((uint64_t)now & 0xffffffffUL));
+    put_u16(&vars, TSIG_FUDGE);
+    put_u16(&vars, 0);                       /* error */
+    put_u16(&vars, 0);                       /* other len */
+    if (vars.overflow || m->overflow) return false;
+
+    unsigned char mac[EVP_MAX_MD_SIZE];
+    unsigned int mac_len = 0;
+    HMAC_CTX *ctx = HMAC_CTX_new();
+    if (!ctx) return false;
+    bool ok = HMAC_Init_ex(ctx, secret, (int)secret_len, EVP_sha256(),
+                           NULL) == 1 &&
+              HMAC_Update(ctx, m->data, m->len) == 1 &&
+              HMAC_Update(ctx, vars.data, vars.len) == 1 &&
+              HMAC_Final(ctx, mac, &mac_len) == 1;
+    HMAC_CTX_free(ctx);
+    if (!ok) return false;
+
+    put_name(m, key_name);
+    put_u16(m, DNS_TYPE_TSIG);
+    put_u16(m, DNS_CLASS_ANY);
+    put_u32(m, 0);
+    /* RDLENGTH, filled in once the record body is written. */
+    size_t rdlength_at = m->len;
+    put_u16(m, 0);
+    size_t rdata_at = m->len;
+    put_name_canonical(m, algorithm);
+    put_u16(m, (unsigned)((uint64_t)now >> 32));
+    put_u32(m, (unsigned long)((uint64_t)now & 0xffffffffUL));
+    put_u16(m, TSIG_FUDGE);
+    put_u16(m, mac_len);
+    put_bytes(m, mac, mac_len);
+    put_u16(m, original_id);
+    put_u16(m, 0);                           /* error */
+    put_u16(m, 0);                           /* other len */
+    if (m->overflow) return false;
+    size_t rdlength = m->len - rdata_at;
+    m->data[rdlength_at] = (unsigned char)(rdlength >> 8);
+    m->data[rdlength_at + 1] = (unsigned char)rdlength;
+
+    /* ARCOUNT, now that the record is in. */
+    unsigned arcount = (unsigned)((m->data[10] << 8) | m->data[11]) + 1;
+    m->data[10] = (unsigned char)(arcount >> 8);
+    m->data[11] = (unsigned char)arcount;
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Transport                                                           */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Send `request` and read one reply, over TCP with the two-byte length prefix
+ * the protocol requires there. UDP is not offered: an update is a write, and
+ * a write answered from a truncated datagram is a write whose outcome is
+ * unknown.
+ */
+static bool exchange(const char *server, const char *port, const msg *request,
+                     unsigned char *reply, size_t reply_cap, size_t *reply_len,
+                     char *error, size_t error_len) {
+    struct addrinfo hints = {0}, *addrs = NULL;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_family = AF_UNSPEC;
+    int rc = getaddrinfo(server, port, &hints, &addrs);
+    if (rc != 0 || !addrs) {
+        snprintf(error, error_len, "cannot resolve %s: %s", server,
+                 gai_strerror(rc));
+        return false;
+    }
+
+    int fd = -1;
+    for (struct addrinfo *a = addrs; a; a = a->ai_next) {
+        fd = socket(a->ai_family, a->ai_socktype, a->ai_protocol);
+        if (fd < 0) continue;
+        struct timeval tv = { DNS_TIMEOUT_SECONDS, 0 };
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        if (connect(fd, a->ai_addr, a->ai_addrlen) == 0) break;
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(addrs);
+    if (fd < 0) {
+        snprintf(error, error_len, "cannot connect to %s:%s", server, port);
+        return false;
+    }
+
+    unsigned char prefix[2] = { (unsigned char)(request->len >> 8),
+                                (unsigned char)request->len };
+    bool ok = true;
+    if (send(fd, prefix, 2, 0) != 2 ||
+        send(fd, request->data, request->len, 0) != (ssize_t)request->len) {
+        snprintf(error, error_len, "cannot send to %s:%s", server, port);
+        ok = false;
+    }
+
+    size_t got = 0;
+    if (ok) {
+        unsigned char len_buf[2];
+        while (got < 2) {
+            ssize_t n = recv(fd, len_buf + got, 2 - got, 0);
+            if (n <= 0) break;
+            got += (size_t)n;
+        }
+        if (got != 2) {
+            snprintf(error, error_len, "no reply from %s:%s", server, port);
+            ok = false;
+        } else {
+            size_t want = (size_t)((len_buf[0] << 8) | len_buf[1]);
+            if (want > reply_cap) {
+                snprintf(error, error_len, "reply from %s too large", server);
+                ok = false;
+            } else {
+                got = 0;
+                while (got < want) {
+                    ssize_t n = recv(fd, reply + got, want - got, 0);
+                    if (n <= 0) break;
+                    got += (size_t)n;
+                }
+                if (got != want) {
+                    snprintf(error, error_len, "short reply from %s", server);
+                    ok = false;
+                } else {
+                    *reply_len = got;
+                }
+            }
+        }
+    }
+    close(fd);
+    return ok;
+}
+
+/* The RCODE names a server reports, so a refusal says which one it was. A
+ * NOTAUTH here almost always means the key is right and the server does not
+ * allow that key to update that zone. */
+static const char *rcode_name(unsigned rcode) {
+    switch (rcode) {
+    case 0: return "NOERROR";
+    case 1: return "FORMERR";
+    case 2: return "SERVFAIL";
+    case 3: return "NXDOMAIN";
+    case 4: return "NOTIMP";
+    case 5: return "REFUSED";
+    case 6: return "YXDOMAIN";
+    case 7: return "YXRRSET";
+    case 8: return "NXRRSET";
+    case 9: return "NOTAUTH";
+    case 10: return "NOTZONE";
+    case 16: return "BADSIG or BADVERS";
+    case 17: return "BADKEY";
+    case 18: return "BADTIME";
+    default: return "unknown";
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Public operations                                                   */
+/* ------------------------------------------------------------------ */
+
+static unsigned random_id(void) {
+    unsigned char bytes[2];
+    FILE *urandom = fopen("/dev/urandom", "rb");
+    if (urandom && fread(bytes, 1, 2, urandom) == 2) {
+        fclose(urandom);
+        return (unsigned)((bytes[0] << 8) | bytes[1]);
+    }
+    if (urandom) fclose(urandom);
+    return (unsigned)(time(NULL) & 0xffff);
+}
+
+wf_status metalbear_rfc2136_query_txt(const metalbear_rfc2136_config *config,
+                                      const char *name, char *out,
+                                      size_t out_len, bool *out_found,
+                                      char *error, size_t error_len) {
+    *out_found = false;
+    if (out_len) out[0] = '\0';
+
+    msg m = {0};
+    unsigned id = random_id();
+    put_u16(&m, id);
+    put_u16(&m, 0x0100);              /* standard query, recursion desired off
+                                       * for an authoritative server; RD is
+                                       * harmless and widely expected */
+    put_u16(&m, 1);                   /* QDCOUNT */
+    put_u16(&m, 0);
+    put_u16(&m, 0);
+    put_u16(&m, 0);                   /* ARCOUNT, raised by tsig_sign */
+    put_name(&m, name);
+    put_u16(&m, DNS_TYPE_TXT);
+    put_u16(&m, DNS_CLASS_IN);
+    if (m.overflow) {
+        snprintf(error, error_len, "name too long: %s", name);
+        return WF_ERR_INVALID_ARG;
+    }
+    if (!tsig_sign(&m, config->key_name, config->secret, config->secret_len,
+                   id)) {
+        snprintf(error, error_len, "could not sign the query");
+        return WF_ERR_INTERNAL;
+    }
+
+    unsigned char reply[4096];
+    size_t reply_len = 0;
+    if (!exchange(config->server, config->port, &m, reply, sizeof(reply),
+                  &reply_len, error, error_len))
+        return WF_ERR_NETWORK;
+    if (reply_len < 12) {
+        snprintf(error, error_len, "truncated reply");
+        return WF_ERR_NETWORK;
+    }
+    unsigned rcode = reply[3] & 0x0f;
+    /* NXDOMAIN and an empty answer are both "no record", which is a normal
+     * state and not an error: it is what every first account on a zone
+     * looks like. */
+    if (rcode == 3) return WF_OK;
+    if (rcode != 0) {
+        snprintf(error, error_len, "query refused: %s", rcode_name(rcode));
+        return WF_ERR_NETWORK;
+    }
+    unsigned ancount = (unsigned)((reply[6] << 8) | reply[7]);
+    if (ancount == 0) return WF_OK;
+
+    /* Skip the question section, then walk answers to the first TXT. */
+    size_t at = 12;
+    unsigned qdcount = (unsigned)((reply[4] << 8) | reply[5]);
+    for (unsigned i = 0; i < qdcount && at < reply_len; i++) {
+        while (at < reply_len && reply[at] != 0) {
+            if ((reply[at] & 0xc0) == 0xc0) { at += 2; goto question_done; }
+            at += reply[at] + 1;
+        }
+        at++;
+question_done:
+        at += 4;                      /* QTYPE + QCLASS */
+    }
+    for (unsigned i = 0; i < ancount && at + 10 <= reply_len; i++) {
+        /* Owner name, which may be a compression pointer. */
+        while (at < reply_len && reply[at] != 0) {
+            if ((reply[at] & 0xc0) == 0xc0) { at += 2; goto name_done; }
+            at += reply[at] + 1;
+        }
+        at++;
+name_done:
+        if (at + 10 > reply_len) break;
+        unsigned type = (unsigned)((reply[at] << 8) | reply[at + 1]);
+        unsigned rdlength = (unsigned)((reply[at + 8] << 8) | reply[at + 9]);
+        at += 10;
+        if (at + rdlength > reply_len) break;
+        if (type == DNS_TYPE_TXT && rdlength >= 1) {
+            /* TXT rdata is one or more length-prefixed strings. A `did=` value
+             * fits in one, and only the first is read: a handle record with a
+             * continuation is not one this server wrote. */
+            unsigned segment = reply[at];
+            if (segment + 1u <= rdlength && segment < out_len) {
+                memcpy(out, reply + at + 1, segment);
+                out[segment] = '\0';
+                *out_found = true;
+                return WF_OK;
+            }
+        }
+        at += rdlength;
+    }
+    return WF_OK;
+}
+
+wf_status metalbear_rfc2136_update_txt(const metalbear_rfc2136_config *config,
+                                       const char *name, const char *value,
+                                       int ttl, char *error,
+                                       size_t error_len) {
+    msg m = {0};
+    unsigned id = random_id();
+    put_u16(&m, id);
+    /* Opcode 5 (UPDATE) in bits 11-14 of the flags word. */
+    put_u16(&m, DNS_OPCODE_UPDATE << 11);
+    put_u16(&m, 1);                   /* ZOCOUNT: the zone */
+    put_u16(&m, 0);                   /* PRCOUNT: no prerequisites */
+    put_u16(&m, value ? 2 : 1);       /* UPCOUNT */
+    put_u16(&m, 0);                   /* ADCOUNT, raised by tsig_sign */
+
+    /* Zone section: the zone, as an SOA question. */
+    put_name(&m, config->zone);
+    put_u16(&m, DNS_TYPE_SOA);
+    put_u16(&m, DNS_CLASS_IN);
+
+    /*
+     * Delete the whole TXT RRset first, then add ours. Deleting is class ANY
+     * with a zero TTL and no rdata; the pair in one message is what makes the
+     * write atomic, so a reader never sees the name with no record at all.
+     */
+    put_name(&m, name);
+    put_u16(&m, DNS_TYPE_TXT);
+    put_u16(&m, DNS_CLASS_ANY);
+    put_u32(&m, 0);
+    put_u16(&m, 0);                   /* RDLENGTH */
+
+    if (value) {
+        size_t value_len = strlen(value);
+        if (value_len > 255) {
+            snprintf(error, error_len, "record value too long");
+            return WF_ERR_INVALID_ARG;
+        }
+        put_name(&m, name);
+        put_u16(&m, DNS_TYPE_TXT);
+        put_u16(&m, DNS_CLASS_IN);
+        put_u32(&m, (unsigned long)(ttl > 0 ? ttl : 300));
+        put_u16(&m, (unsigned)value_len + 1);
+        put_u8(&m, (unsigned)value_len);
+        put_bytes(&m, value, value_len);
+    }
+
+    if (m.overflow) {
+        snprintf(error, error_len, "update message too large");
+        return WF_ERR_INVALID_ARG;
+    }
+    if (!tsig_sign(&m, config->key_name, config->secret, config->secret_len,
+                   id)) {
+        snprintf(error, error_len, "could not sign the update");
+        return WF_ERR_INTERNAL;
+    }
+
+    unsigned char reply[4096];
+    size_t reply_len = 0;
+    if (!exchange(config->server, config->port, &m, reply, sizeof(reply),
+                  &reply_len, error, error_len))
+        return WF_ERR_NETWORK;
+    if (reply_len < 12) {
+        snprintf(error, error_len, "truncated reply to the update");
+        return WF_ERR_NETWORK;
+    }
+    unsigned rcode = reply[3] & 0x0f;
+    if (rcode != 0) {
+        snprintf(error, error_len, "update refused: %s", rcode_name(rcode));
+        return WF_ERR_NETWORK;
+    }
+    return WF_OK;
+}

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,124 @@
+/*
+ * log.c — the process's log.
+ *
+ * Extracted from the server so the daemon writes its startup and shutdown
+ * messages the same way: a bare fprintf to stderr alongside a JSON stream
+ * produces a line no collector accepts, and it is invariably the line saying
+ * why the server would not start.
+ */
+
+#include "metalbear/log.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static metalbear_log_level log_level = METALBEAR_LOG_INFO;
+static FILE *log_file = NULL;
+
+static metalbear_log_level metalbear_log_level_from_env(void) {
+    const char *level = getenv("METALBEAR_LOG_LEVEL");
+    if (!level || !level[0]) return METALBEAR_LOG_INFO;
+    if (strcmp(level, "debug") == 0 || strcmp(level, "DEBUG") == 0) return METALBEAR_LOG_DEBUG;
+    if (strcmp(level, "info") == 0 || strcmp(level, "INFO") == 0) return METALBEAR_LOG_INFO;
+    if (strcmp(level, "warn") == 0 || strcmp(level, "WARN") == 0) return METALBEAR_LOG_WARN;
+    if (strcmp(level, "error") == 0 || strcmp(level, "ERROR") == 0) return METALBEAR_LOG_ERROR;
+    char *end = NULL;
+    long v = strtol(level, &end, 10);
+    if (end && *end == '\0' && v >= 0 && v <= 3) return (int)v;
+    return METALBEAR_LOG_INFO;
+}
+
+static FILE *metalbear_log_file_from_env(void) {
+    const char *path = getenv("METALBEAR_LOG_FILE");
+    if (!path || !path[0]) return NULL;
+    return fopen(path, "a");
+}
+
+/*
+ * Whether to emit one JSON object per line instead of the human-readable
+ * form. Log collectors parse the former; a person reading a terminal wants
+ * the latter, so it stays the default.
+ */
+static bool log_json = false;
+
+static bool metalbear_log_json_from_env(void) {
+    const char *format = getenv("METALBEAR_LOG_FORMAT");
+    return format && (strcmp(format, "json") == 0 ||
+                      strcmp(format, "JSON") == 0);
+}
+
+/* Escape a log message into a JSON string body (without the quotes). Control
+ * characters are escaped rather than passed through: a message carrying a
+ * newline would otherwise split one event into two malformed ones. */
+static void json_escape_into(FILE *out, const char *text) {
+    for (const unsigned char *p = (const unsigned char *)text; *p; p++) {
+        switch (*p) {
+        case '"':  fputs("\\\"", out); break;
+        case '\\': fputs("\\\\", out); break;
+        case '\n': fputs("\\n", out); break;
+        case '\r': fputs("\\r", out); break;
+        case '\t': fputs("\\t", out); break;
+        default:
+            if (*p < 0x20) fprintf(out, "\\u%04x", *p);
+            else fputc(*p, out);
+        }
+    }
+}
+
+void metalbear_log(metalbear_log_level level, const char *fmt, ...) {
+    if (level < log_level) return;
+    static const char *level_names[] = {"debug", "info", "warn", "error"};
+    va_list args;
+    FILE *out = log_file ? log_file : stderr;
+    time_t now = time(NULL);
+    struct tm tm;
+    /*
+     * UTC, because the line says so. This used to format local time and
+     * append a `Z`, which reads as a correct timestamp in the wrong zone —
+     * the kind of error that only surfaces when two hosts' logs are lined up
+     * against each other during an incident.
+     */
+    gmtime_r(&now, &tm);
+    char ts[32];
+    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm);
+
+    if (log_json) {
+        char message[2048];
+        va_start(args, fmt);
+        vsnprintf(message, sizeof(message), fmt, args);
+        va_end(args);
+        fprintf(out, "{\"time\":\"%s\",\"level\":\"%s\",\"service\":"
+                     "\"metalbear\",\"message\":\"", ts,
+                level_names[level]);
+        json_escape_into(out, message);
+        fputs("\"}\n", out);
+    } else {
+        static const char *display[] = {"DEBUG", "INFO", "WARN", "ERROR"};
+        fprintf(out, "MetalBear [%s] [%s] ", display[level], ts);
+        va_start(args, fmt);
+        vfprintf(out, fmt, args);
+        va_end(args);
+        fprintf(out, "\n");
+    }
+    if (log_file) fflush(log_file);
+}
+
+void metalbear_log_configure(void) {
+    log_level = metalbear_log_level_from_env();
+    log_json = metalbear_log_json_from_env();
+    FILE *opened = metalbear_log_file_from_env();
+    if (opened) {
+        if (log_file) fclose(log_file);
+        log_file = opened;
+    }
+}
+
+void metalbear_log_close(void) {
+    if (!log_file) return;
+    fclose(log_file);
+    log_file = NULL;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 
 #include "metalbear/config_file.h"
 #include "metalbear/server.h"
+#include "metalbear/log.h"
 
 #include <errno.h>
 #include <signal.h>
@@ -71,7 +72,7 @@ static char *path_join(const char *dir, const char *name) {
 static const char *required_env(const char *name) {
     const char *value = getenv(name);
     if (!value || !value[0])
-        fprintf(stderr, "MetalBear [ERROR] missing required %s\n", name);
+        LOG_ERROR("missing required %s", name);
     return value;
 }
 
@@ -93,8 +94,7 @@ static int did_env_is_usable(const char *name, const char *value) {
     if (!value || !value[0]) return 0; /* required_env already complained */
 
     if (!wf_syntax_did_is_valid(value)) {
-        fprintf(stderr, "MetalBear [ERROR] %s is not a valid DID: %s\n",
-                name, value);
+        LOG_ERROR("%s is not a valid DID: %s", name, value);
         return 0;
     }
     if (strncmp(value, "did:plc:", 8) == 0 && !wf_syntax_did_plc_is_valid(value)) {
@@ -130,6 +130,9 @@ static void print_usage(FILE *out, const char *argv0) {
 }
 
 int main(int argc, char **argv) {
+    /* Before any message can be emitted, so configuration errors come out in
+     * the format the operator asked for. */
+    metalbear_log_configure();
     /*
      * Handled before anything else reads configuration: asking a binary what
      * version it is must work on a host that has none, which is exactly the
@@ -145,7 +148,7 @@ int main(int argc, char **argv) {
             print_usage(stdout, argv0);
             return 0;
         }
-        fprintf(stderr, "MetalBear [ERROR] unknown argument: %s\n", argv[i]);
+        LOG_ERROR("unknown argument: %s", argv[i]);
         print_usage(stderr, argv0);
         return 2;
     }
@@ -197,11 +200,10 @@ int main(int argc, char **argv) {
                                        cfg_err, sizeof(cfg_err)) != WF_OK) {
             /* A config file that cannot be read is fatal: starting with
              * defaults would silently ignore what the operator asked for. */
-            fprintf(stderr, "MetalBear [ERROR] %s\n",
-                    cfg_err[0] ? cfg_err : "could not read config file");
+            LOG_ERROR("%s", cfg_err[0] ? cfg_err : "could not read config file");
             return 2;
         }
-        fprintf(stderr, "MetalBear [INFO] loaded config from %s\n", config_path);
+        LOG_INFO("loaded config from %s", config_path);
     }
 
     /* Environment overrides the file, one setting at a time. */
@@ -269,13 +271,11 @@ int main(int argc, char **argv) {
         }
     }
     if (!config.service_did) {
-        fprintf(stderr, "MetalBear [ERROR] METALBEAR_SERVICE_DID or "
-                        "server.service_did is required\n");
+        LOG_ERROR("METALBEAR_SERVICE_DID or server.service_did is required");
         return 2;
     }
     if (!config.user_domain) {
-        fprintf(stderr, "MetalBear [ERROR] METALBEAR_USER_DOMAIN or "
-                        "server.user_domain is required\n");
+        LOG_ERROR("METALBEAR_USER_DOMAIN or server.user_domain is required");
         return 2;
     }
     /* Refuse to start on a malformed service identity rather than bake it into
@@ -318,14 +318,14 @@ int main(int argc, char **argv) {
 
     metalbear_server *server = metalbear_server_start(&config);
     if (!server) {
-        fprintf(stderr, "MetalBear [ERROR] failed to start MetalBear\n");
+        LOG_ERROR("failed to start MetalBear");
         return 1;
     }
 
     signal(SIGINT, stop_handler);
     signal(SIGTERM, stop_handler);
-    fprintf(stderr, "MetalBear [INFO] listening on %s:%u\n",
-            config.listen_address, (unsigned)metalbear_server_port(server));
+    LOG_INFO("listening on %s:%u", config.listen_address,
+             (unsigned)metalbear_server_port(server));
     while (!stopping) pause();
     metalbear_server_free(server);
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -241,6 +241,7 @@ int main(int argc, char **argv) {
     ENV_STR("METALBEAR_DNS_PROVIDER",      dns_provider);
     ENV_STR("METALBEAR_DNS_API_TOKEN",     dns_api_token);
     ENV_STR("METALBEAR_DNS_ZONE_ID",       dns_zone_id);
+    ENV_STR("METALBEAR_DNS_SERVER",        dns_server);
 
     ENV_I64("METALBEAR_RATE_LIMIT",              rate_limit);
     ENV_I64("METALBEAR_RATE_LIMIT_WINDOW",       rate_limit_window);

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -9,8 +9,12 @@
 
 #include "metalbear/metrics.h"
 
+#include <pthread.h>
 #include <stdatomic.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 
 static _Atomic uint64_t counters[METALBEAR_METRIC_COUNT];
 
@@ -20,11 +24,13 @@ static const struct {
     const char *name;
     const char *help;
 } descriptions[METALBEAR_METRIC_COUNT] = {
-    [METALBEAR_METRIC_XRPC_REQUESTS] =
-        { "xrpc_requests_total", "XRPC requests received." },
-    [METALBEAR_METRIC_XRPC_REJECTED] =
-        { "xrpc_rejected_total",
-          "XRPC requests refused before a handler ran." },
+    [METALBEAR_METRIC_REQUESTS] =
+        { "requests_total", "Requests served." },
+    [METALBEAR_METRIC_REQUESTS_FAILED] =
+        { "requests_failed_total", "Requests that answered 4xx or 5xx." },
+    [METALBEAR_METRIC_AUTH_REFUSED] =
+        { "auth_refused_total",
+          "Requests refused by the authentication callback." },
     [METALBEAR_METRIC_ACCOUNTS_CREATED] =
         { "accounts_created_total", "Accounts created on this host." },
     [METALBEAR_METRIC_ACCOUNTS_DELETED] =
@@ -72,7 +78,91 @@ const char *metalbear_metric_help(metalbear_metric metric) {
     return descriptions[metric].help;
 }
 
+
+/* ------------------------------------------------------------------ */
+/* Per-route accounting                                                */
+/* ------------------------------------------------------------------ */
+
+/*
+ * A small open table guarded by one mutex rather than an atomic per row: a
+ * route has to be found before it can be incremented, and a lookup that races
+ * an insert is how the same NSID ends up occupying two rows and reporting half
+ * its traffic in each.
+ *
+ * The lock is held for a string compare over a bounded table. That is
+ * comfortably cheaper than the SQLite transaction and the secp256k1 signature
+ * on the write path it sits beside.
+ */
+typedef struct route_row {
+    char name[128];
+    uint64_t requests;
+    uint64_t errors;
+} route_row;
+
+static route_row routes[METALBEAR_METRICS_MAX_ROUTES];
+static size_t route_count;
+static pthread_mutex_t routes_lock = PTHREAD_MUTEX_INITIALIZER;
+/* Requests that arrived after the table filled up. Counted rather than
+ * dropped, so the per-route numbers always sum to the total. */
+static uint64_t overflow_requests;
+static uint64_t overflow_errors;
+
+void metalbear_metrics_record_request(const char *nsid, const char *path,
+                                      unsigned int status) {
+    const char *name = (nsid && nsid[0]) ? nsid : path;
+    if (!name || !name[0]) name = "unknown";
+    bool is_error = status >= 400;
+
+    pthread_mutex_lock(&routes_lock);
+    for (size_t i = 0; i < route_count; i++) {
+        if (strcmp(routes[i].name, name) == 0) {
+            routes[i].requests++;
+            if (is_error) routes[i].errors++;
+            pthread_mutex_unlock(&routes_lock);
+            return;
+        }
+    }
+    if (route_count < METALBEAR_METRICS_MAX_ROUTES) {
+        route_row *row = &routes[route_count++];
+        snprintf(row->name, sizeof(row->name), "%s", name);
+        row->requests = 1;
+        row->errors = is_error ? 1 : 0;
+    } else {
+        overflow_requests++;
+        if (is_error) overflow_errors++;
+    }
+    pthread_mutex_unlock(&routes_lock);
+}
+
+void metalbear_metrics_visit_routes(metalbear_metrics_route_visitor visit,
+                                    void *ctx) {
+    if (!visit) return;
+    /*
+     * Copied out under the lock and visited outside it. The visitor formats
+     * into a growing buffer, and holding a lock the request path needs across
+     * an allocation is how a scrape starts blocking writes.
+     */
+    route_row snapshot[METALBEAR_METRICS_MAX_ROUTES];
+    size_t count;
+    uint64_t spilled_requests, spilled_errors;
+    pthread_mutex_lock(&routes_lock);
+    count = route_count;
+    memcpy(snapshot, routes, count * sizeof(route_row));
+    spilled_requests = overflow_requests;
+    spilled_errors = overflow_errors;
+    pthread_mutex_unlock(&routes_lock);
+
+    for (size_t i = 0; i < count; i++)
+        visit(ctx, snapshot[i].name, snapshot[i].requests, snapshot[i].errors);
+    if (spilled_requests) visit(ctx, "other", spilled_requests, spilled_errors);
+}
+
 void metalbear_metrics_reset(void) {
     for (int i = 0; i < METALBEAR_METRIC_COUNT; i++)
         atomic_store_explicit(&counters[i], 0, memory_order_relaxed);
+    pthread_mutex_lock(&routes_lock);
+    route_count = 0;
+    overflow_requests = 0;
+    overflow_errors = 0;
+    pthread_mutex_unlock(&routes_lock);
 }

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -1,0 +1,78 @@
+/*
+ * metrics.c — the counter table behind `GET /metrics`.
+ *
+ * One atomic per metric, incremented from the request path. Relaxed ordering
+ * is deliberate: a counter carries no happens-before relationship with
+ * anything else, and a scrape reading a value one increment stale is
+ * indistinguishable from a scrape that arrived a microsecond earlier.
+ */
+
+#include "metalbear/metrics.h"
+
+#include <stdatomic.h>
+#include <stddef.h>
+
+static _Atomic uint64_t counters[METALBEAR_METRIC_COUNT];
+
+/* Name and help text, in enum order. Kept beside the enum rather than built
+ * at the call site so a metric cannot be exported under two spellings. */
+static const struct {
+    const char *name;
+    const char *help;
+} descriptions[METALBEAR_METRIC_COUNT] = {
+    [METALBEAR_METRIC_XRPC_REQUESTS] =
+        { "xrpc_requests_total", "XRPC requests received." },
+    [METALBEAR_METRIC_XRPC_REJECTED] =
+        { "xrpc_rejected_total",
+          "XRPC requests refused before a handler ran." },
+    [METALBEAR_METRIC_ACCOUNTS_CREATED] =
+        { "accounts_created_total", "Accounts created on this host." },
+    [METALBEAR_METRIC_ACCOUNTS_DELETED] =
+        { "accounts_deleted_total", "Accounts deleted from this host." },
+    [METALBEAR_METRIC_SESSIONS_CREATED] =
+        { "sessions_created_total", "Sessions issued." },
+    [METALBEAR_METRIC_LOGIN_FAILURES] =
+        { "login_failures_total", "Logins refused." },
+    [METALBEAR_METRIC_COMMITS_SEQUENCED] =
+        { "commits_sequenced_total",
+          "Signed repository commits published to the firehose." },
+    [METALBEAR_METRIC_BLOBS_UPLOADED] =
+        { "blobs_uploaded_total", "Blobs stored." },
+    [METALBEAR_METRIC_TAKEDOWNS_APPLIED] =
+        { "takedowns_applied_total", "Takedowns applied to a subject." },
+    [METALBEAR_METRIC_FIREHOSE_SUBSCRIBES] =
+        { "firehose_subscribes_total",
+          "Firehose subscribers that have connected." },
+    [METALBEAR_METRIC_FIREHOSE_DISCONNECTS] =
+        { "firehose_disconnects_total",
+          "Firehose subscribers that have disconnected." },
+    [METALBEAR_METRIC_DNS_FAILURES] =
+        { "dns_failures_total", "Handle DNS records that could not be written." },
+    [METALBEAR_METRIC_CRAWL_FAILURES] =
+        { "crawl_failures_total", "requestCrawl announcements that failed." },
+};
+
+void metalbear_metrics_inc(metalbear_metric metric) {
+    if (metric < 0 || metric >= METALBEAR_METRIC_COUNT) return;
+    atomic_fetch_add_explicit(&counters[metric], 1, memory_order_relaxed);
+}
+
+uint64_t metalbear_metrics_get(metalbear_metric metric) {
+    if (metric < 0 || metric >= METALBEAR_METRIC_COUNT) return 0;
+    return atomic_load_explicit(&counters[metric], memory_order_relaxed);
+}
+
+const char *metalbear_metric_name(metalbear_metric metric) {
+    if (metric < 0 || metric >= METALBEAR_METRIC_COUNT) return NULL;
+    return descriptions[metric].name;
+}
+
+const char *metalbear_metric_help(metalbear_metric metric) {
+    if (metric < 0 || metric >= METALBEAR_METRIC_COUNT) return NULL;
+    return descriptions[metric].help;
+}
+
+void metalbear_metrics_reset(void) {
+    for (int i = 0; i < METALBEAR_METRIC_COUNT; i++)
+        atomic_store_explicit(&counters[i], 0, memory_order_relaxed);
+}

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -100,6 +100,22 @@ static int64_t pruned_through(metalbear_sequencer *s) {
     return pruned;
 }
 
+/*
+ * The account an event belongs to. Every event kind the log stores carries a
+ * DID; the ones that do not (#info, #labels, #error) are never appended here.
+ * Recorded alongside the frame so an account's events can be found without
+ * decoding every frame in the log.
+ */
+static const char *event_did(const wf_subscribe_event *event) {
+    switch (event->type) {
+    case WF_SUBSCRIBE_EVENT_COMMIT:   return event->data.commit.did;
+    case WF_SUBSCRIBE_EVENT_SYNC:     return event->data.sync.did;
+    case WF_SUBSCRIBE_EVENT_IDENTITY: return event->data.identity.did;
+    case WF_SUBSCRIBE_EVENT_ACCOUNT:  return event->data.account.did;
+    default:                          return NULL;
+    }
+}
+
 static wf_status append_event(metalbear_sequencer *s,
                               wf_subscribe_event *event) {
     sqlite3_stmt *stmt = NULL;
@@ -111,12 +127,18 @@ static wf_status append_event(metalbear_sequencer *s,
                                    NULL) != SQLITE_OK)
         goto done;
     if (sqlite3_prepare_v2(s->db,
-            "INSERT INTO events(frame,created_at) VALUES(zeroblob(0),?);",
+            "INSERT INTO events(frame,created_at,did) "
+            "VALUES(zeroblob(0),?,?);",
             -1, &stmt, NULL) != SQLITE_OK)
         goto rollback;
     char now[64];
     timestamp_now(now);
     sqlite3_bind_text(stmt, 1, now, -1, SQLITE_TRANSIENT);
+    const char *did = event_did(event);
+    if (did && did[0])
+        sqlite3_bind_text(stmt, 2, did, -1, SQLITE_TRANSIENT);
+    else
+        sqlite3_bind_null(stmt, 2);
     if (sqlite3_step(stmt) != SQLITE_DONE) goto rollback;
     sqlite3_finalize(stmt);
     stmt = NULL;
@@ -296,6 +318,34 @@ static wf_status seed_sequence_floor(metalbear_sequencer *s) {
     return WF_OK;
 }
 
+/*
+ * Add the `did` column to a log written before it existed. The CREATE above
+ * only applies to a log being made now, and a running host's sequencer file is
+ * the one thing it cannot be asked to discard — its sequence numbers are held
+ * by every consumer that ever subscribed.
+ *
+ * Rows already in the log keep a NULL did. They are still found, by the
+ * substring match in metalbear_sequencer_purge_account, rather than by
+ * backfilling: a backfill would have to decode every frame in a log that can
+ * hold months of commits, at startup, on a host that has no reason to wait.
+ */
+static wf_status add_did_column(metalbear_sequencer *s) {
+    sqlite3_stmt *stmt = NULL;
+    bool present = false;
+    if (sqlite3_prepare_v2(s->db, "PRAGMA table_info(events);", -1, &stmt,
+                           NULL) != SQLITE_OK)
+        return WF_ERR_INTERNAL;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *name = (const char *)sqlite3_column_text(stmt, 1);
+        if (name && strcmp(name, "did") == 0) present = true;
+    }
+    sqlite3_finalize(stmt);
+    if (present) return WF_OK;
+    return sqlite3_exec(s->db, "ALTER TABLE events ADD COLUMN did TEXT;",
+                        NULL, NULL, NULL) == SQLITE_OK
+        ? WF_OK : WF_ERR_INTERNAL;
+}
+
 wf_status metalbear_sequencer_open(const char *path,
                                    metalbear_sequencer **out) {
     if (!path || !out) return WF_ERR_INVALID_ARG;
@@ -316,10 +366,14 @@ wf_status metalbear_sequencer_open(const char *path,
             "PRAGMA journal_mode=WAL;"
             "CREATE TABLE IF NOT EXISTS events("
             "seq INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "frame BLOB NOT NULL,created_at TEXT NOT NULL);"
+            "frame BLOB NOT NULL,created_at TEXT NOT NULL,did TEXT);"
             /* Retention's high-water mark lives here: see pruned_through(). */
             "CREATE TABLE IF NOT EXISTS meta("
             "key TEXT PRIMARY KEY,value INTEGER NOT NULL);",
+            NULL, NULL, NULL) != SQLITE_OK ||
+        add_did_column(s) != WF_OK ||
+        sqlite3_exec(s->db,
+            "CREATE INDEX IF NOT EXISTS events_did ON events(did);",
             NULL, NULL, NULL) != SQLITE_OK ||
         seed_sequence_floor(s) != WF_OK) {
         metalbear_sequencer_free(s);
@@ -796,6 +850,52 @@ wf_status metalbear_sequencer_retain(metalbear_sequencer *s,
     }
     pthread_mutex_unlock(&s->mutex);
     return WF_OK;
+}
+
+wf_status metalbear_sequencer_purge_account(metalbear_sequencer *s,
+                                            const char *did,
+                                            int64_t *out_removed) {
+    if (out_removed) *out_removed = 0;
+    if (!s || !did || !did[0]) return WF_ERR_INVALID_ARG;
+    pthread_mutex_lock(&s->mutex);
+    /*
+     * Everything for this DID except its most recent event, which is the
+     * `deleted` #account announcement the caller has just sequenced. Keeping
+     * it is the whole point: a consumer that has never heard of the deletion
+     * would otherwise see the account's history simply stop, which is what a
+     * host going quiet looks like too.
+     *
+     * Identified by the recorded DID, or by the DID appearing in the frame
+     * for rows written before the column existed. The needle is bound as a
+     * blob because the frame is one, and a text needle would be compared
+     * under a different affinity.
+     */
+    sqlite3_stmt *stmt = NULL;
+    wf_status status = WF_OK;
+    if (sqlite3_prepare_v2(s->db,
+            "DELETE FROM events WHERE "
+            "(did = ?1 OR (did IS NULL AND instr(frame, ?2) > 0)) "
+            "AND seq < (SELECT MAX(seq) FROM events WHERE "
+            "  did = ?1 OR (did IS NULL AND instr(frame, ?2) > 0));",
+            -1, &stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, did, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_blob(stmt, 2, did, (int)strlen(did), SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) != SQLITE_DONE) status = WF_ERR_INTERNAL;
+    } else {
+        status = WF_ERR_INTERNAL;
+    }
+    sqlite3_finalize(stmt);
+    if (status == WF_OK && out_removed)
+        *out_removed = (int64_t)sqlite3_changes(s->db);
+    /*
+     * No pruned_through mark is written. That records where the *start* of
+     * the log was trimmed, so a subscriber resuming from before it can be
+     * told its cursor is outdated. This removes rows from the middle, and a
+     * reader that asks for the next event after a cursor never sees the gap:
+     * sequence numbers are not required to be contiguous, only to increase.
+     */
+    pthread_mutex_unlock(&s->mutex);
+    return status;
 }
 
 void metalbear_sequencer_free(metalbear_sequencer *s) {

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include "metalbear/sequencer.h"
+#include "metalbear/metrics.h"
 
 #include "wolfram/sync_publish.h"
 
@@ -181,6 +182,10 @@ static wf_status append_event(metalbear_sequencer *s,
     if (sqlite3_exec(s->db, "COMMIT;", NULL, NULL, NULL) != SQLITE_OK)
         goto rollback;
     status = WF_OK;
+    /* Counted after the transaction commits, so a rolled-back append does not
+     * show up as a commit the network was told about. */
+    if (event->type == WF_SUBSCRIBE_EVENT_COMMIT)
+        metalbear_metrics_inc(METALBEAR_METRIC_COMMITS_SEQUENCED);
     pthread_cond_broadcast(&s->changed);
     goto done;
 
@@ -620,6 +625,7 @@ void metalbear_sequencer_set_ping_seconds(int64_t seconds) {
 
 static void *subscriber_main(void *raw) {
     subscriber_worker *worker = raw;
+    metalbear_metrics_inc(METALBEAR_METRIC_FIREHOSE_SUBSCRIBES);
     metalbear_sequencer *s = worker->sequencer;
     if (worker->error) {
         unsigned char *frame = NULL;
@@ -726,6 +732,7 @@ static void *subscriber_main(void *raw) {
     }
     wf_xrpc_server_ws_release(worker->stream);
     free(worker);
+    metalbear_metrics_inc(METALBEAR_METRIC_FIREHOSE_DISCONNECTS);
     return NULL;
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -738,9 +738,16 @@ static wf_status delete_account(void *ctx, const wf_xrpc_request *request,
     metalbear_account_registry_remove(server->registry, acct->did);
     metalbear_account_registry_clear_takedowns_for_did(server->registry,
                                                        acct->did);
-    /* Emit deactivation event to firehose */
-    metalbear_sequencer_account_status(acct->sequencer, acct->did, 0,
+    /* Emit deletion event to firehose, against the host log rather than a
+     * resolved context's, then drop everything else this DID ever published:
+     * leaving it there hands the repository of somebody who asked to be gone
+     * to any consumer backfilling from an old cursor. */
+    metalbear_sequencer_account_status(server->sequencer, acct->did, 0,
                                        "deleted");
+    int64_t purged = 0;
+    metalbear_sequencer_purge_account(server->sequencer, acct->did, &purged);
+    LOG_INFO("delete_account: purged %lld firehose events for did=%s",
+             (long long)purged, acct->did);
     /* Drop the handle's TXT record: leaving it would keep pointing resolvers
      * at a DID this host no longer serves. */
     retract_handle_dns(server, acct->handle);
@@ -5053,6 +5060,18 @@ static wf_status admin_delete_account(void *ctx,
      */
     metalbear_sequencer_account_status(server->sequencer, did->valuestring, 0,
                                        "deleted");
+    /*
+     * Then drop everything else this DID ever published. The data directory
+     * is about to be removed, and leaving the same records on the firehose
+     * would keep serving them to any consumer backfilling from an old cursor
+     * — a deletion that removes the copy nobody reads and keeps the copy the
+     * network does.
+     */
+    int64_t purged = 0;
+    metalbear_sequencer_purge_account(server->sequencer, did->valuestring,
+                                      &purged);
+    LOG_INFO("admin_delete_account: purged %lld firehose events for did=%s",
+             (long long)purged, did->valuestring);
 
     metalbear_account_registry_remove(server->registry, did->valuestring);
     /* Moderation state goes with it: a DID re-registered later must not

--- a/src/server.c
+++ b/src/server.c
@@ -7445,14 +7445,18 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
      * long after the accounts exist.
      */
     if (config->dns_provider && config->dns_provider[0]) {
-        if (metalbear_handle_dns_open(config->dns_provider,
-                                      config->dns_api_token,
-                                      config->dns_zone_id,
-                                      (int)config->dns_record_ttl,
-                                      &server->handle_dns) != WF_OK) {
-            LOG_ERROR("dns: provider '%s' is configured but unusable; it needs "
-                      "an api_token and a zone_id, and 'cloudflare' is the only "
-                      "provider implemented", config->dns_provider);
+        if (metalbear_handle_dns_open_ex(config->dns_provider,
+                                         config->dns_api_token,
+                                         config->dns_zone_id,
+                                         config->dns_server,
+                                         (int)config->dns_record_ttl,
+                                         &server->handle_dns) != WF_OK) {
+            LOG_ERROR("dns: provider '%s' is configured but unusable. It needs "
+                      "an api_token and a zone_id; 'rfc2136' additionally "
+                      "needs a server, and its api_token is the TSIG key as "
+                      "'<name>:<base64 secret>'. Known providers are "
+                      "cloudflare, digitalocean, desec and rfc2136",
+                      config->dns_provider);
             metalbear_server_free(server);
             return NULL;
         }

--- a/src/server.c
+++ b/src/server.c
@@ -424,15 +424,13 @@ static bool account_is_taken_down(metalbear_server *server, const char *did);
 static wf_status authenticate_request(wf_xrpc_request *req, void *ctx);
 
 /*
- * Wraps the auth callback purely to count. It is the one place every XRPC
- * request passes through, public routes included, and wrapping it means a
- * refusal added later cannot forget to be counted — which is the whole value
- * of the rejected/total ratio as a signal.
+ * Wraps the auth callback to count refusals it makes for a reason the status
+ * alone does not carry: the observer sees a 401, but not whether it came from
+ * a missing token, an expired one, or an account that may not act.
  */
 static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
-    metalbear_metrics_inc(METALBEAR_METRIC_XRPC_REQUESTS);
     wf_status status = authenticate_request(req, ctx);
-    if (status != WF_OK) metalbear_metrics_inc(METALBEAR_METRIC_XRPC_REJECTED);
+    if (status != WF_OK) metalbear_metrics_inc(METALBEAR_METRIC_AUTH_REFUSED);
     return status;
 }
 
@@ -6307,6 +6305,58 @@ static wf_status tls_check_handler(void *ctx, const wf_xrpc_request *req,
  * unauthenticated caller an unbounded amount of work per request. Prometheus
  * has had basic_auth in its scrape config for as long as it has existed.
  */
+/* Prometheus label values may not contain a raw quote, backslash or newline;
+ * a route name arrives from the network and could hold any of them, and one
+ * bad character loses the whole exposition rather than one series. */
+static bool append_escaped_label(sb_t *sb, const char *value) {
+    char escaped[256];
+    size_t o = 0;
+    for (const char *p = value; *p && o + 2 < sizeof(escaped); p++) {
+        if (*p == '"' || *p == '\\') escaped[o++] = '\\';
+        else if (*p == '\n') { escaped[o++] = '\\'; escaped[o++] = 'n'; continue; }
+        escaped[o++] = *p;
+    }
+    escaped[o] = '\0';
+    return sb_append(sb, "%s", escaped);
+}
+
+typedef struct route_render {
+    sb_t *sb;
+    bool ok;
+} route_render;
+
+static void render_route(void *ctx, const char *route, uint64_t requests,
+                         uint64_t errors) {
+    route_render *out = ctx;
+    if (!out->ok) return;
+    out->ok = sb_append(out->sb, "metalbear_route_requests_total{route=\"") &&
+              append_escaped_label(out->sb, route) &&
+              sb_append(out->sb, "\"} %llu\n", (unsigned long long)requests) &&
+              sb_append(out->sb, "metalbear_route_errors_total{route=\"") &&
+              append_escaped_label(out->sb, route) &&
+              sb_append(out->sb, "\"} %llu\n", (unsigned long long)errors);
+}
+
+#ifdef WF_XRPC_HAS_REQUEST_OBSERVER
+/*
+ * Every finished request, with the status it answered.
+ *
+ * Counted here rather than in the auth callback, which is where the totals
+ * used to come from: that callback runs before the status is known, never
+ * runs for the plain HTTP routes, and never runs for a request the rate
+ * limiter refused — so the old totals were a subset that could not be named
+ * and carried no outcome at all.
+ */
+static void observe_request(void *ctx, const char *nsid, const char *path,
+                            const char *method, unsigned int status) {
+    (void)ctx;
+    (void)method;
+    metalbear_metrics_inc(METALBEAR_METRIC_REQUESTS);
+    if (status >= 400) metalbear_metrics_inc(METALBEAR_METRIC_REQUESTS_FAILED);
+    metalbear_metrics_record_request(nsid, path, status);
+}
+#endif
+
 static wf_status metrics_handler(void *ctx, const wf_xrpc_request *req,
                                  wf_xrpc_response *resp) {
     metalbear_server *server = ctx;
@@ -6332,6 +6382,24 @@ static wf_status metrics_handler(void *ctx, const wf_xrpc_request *req,
                        "metalbear_%s %llu\n",
                        name, help ? help : "", name, name,
                        (unsigned long long)metalbear_metrics_get(i));
+    }
+
+    /*
+     * Per-route series. The label is escaped because a route name reaches
+     * here from the network — the AppView proxy forwards NSIDs this server
+     * has never heard of — and a quote inside a label value produces an
+     * exposition Prometheus rejects wholesale, losing every other metric with
+     * it.
+     */
+    if (ok) {
+        ok = sb_append(&sb,
+            "# HELP metalbear_route_requests_total Requests per route.\n"
+            "# TYPE metalbear_route_requests_total counter\n"
+            "# HELP metalbear_route_errors_total 4xx and 5xx responses per route.\n"
+            "# TYPE metalbear_route_errors_total counter\n");
+        route_render ctx_render = { &sb, ok };
+        metalbear_metrics_visit_routes(render_route, &ctx_render);
+        ok = ctx_render.ok;
     }
 
     /* Account counts, read from the registry at scrape time. */
@@ -7129,6 +7197,12 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
     }
 
     wf_xrpc_server_set_auth_callback(server->xrpc, authenticate, server);
+#ifdef WF_XRPC_HAS_REQUEST_OBSERVER
+    /* Guarded so this still builds against a Wolfram without the observer;
+     * without it the per-route breakdown is simply absent rather than the
+     * build being broken. */
+    wf_xrpc_server_set_request_observer(server->xrpc, observe_request, server);
+#endif
 
     /* Register OAuth HTTP routes (bypass XRPC auth) */
     /* One OAuth store for the host. The account a token speaks for comes from

--- a/src/server.c
+++ b/src/server.c
@@ -5,6 +5,8 @@
 #endif
 
 #include "metalbear/server.h"
+#include "metalbear/log.h"
+#include "metalbear/metrics.h"
 #include "metalbear/account.h"
 #include "metalbear/account_registry.h"
 #include "metalbear/account_context.h"
@@ -44,61 +46,7 @@
 #include <ftw.h>
 #include <curl/curl.h>
 
-typedef enum metalbear_log_level {
-    METALBEAR_LOG_DEBUG = 0,
-    METALBEAR_LOG_INFO,
-    METALBEAR_LOG_WARN,
-    METALBEAR_LOG_ERROR,
-} metalbear_log_level;
-
-static metalbear_log_level log_level = METALBEAR_LOG_INFO;
-static FILE *log_file = NULL;
-
-static metalbear_log_level metalbear_log_level_from_env(void) {
-    const char *level = getenv("METALBEAR_LOG_LEVEL");
-    if (!level || !level[0]) return METALBEAR_LOG_INFO;
-    if (strcmp(level, "debug") == 0 || strcmp(level, "DEBUG") == 0) return METALBEAR_LOG_DEBUG;
-    if (strcmp(level, "info") == 0 || strcmp(level, "INFO") == 0) return METALBEAR_LOG_INFO;
-    if (strcmp(level, "warn") == 0 || strcmp(level, "WARN") == 0) return METALBEAR_LOG_WARN;
-    if (strcmp(level, "error") == 0 || strcmp(level, "ERROR") == 0) return METALBEAR_LOG_ERROR;
-    char *end = NULL;
-    long v = strtol(level, &end, 10);
-    if (end && *end == '\0' && v >= 0 && v <= 3) return (int)v;
-    return METALBEAR_LOG_INFO;
-}
-
-static FILE *metalbear_log_file_from_env(void) {
-    const char *path = getenv("METALBEAR_LOG_FILE");
-    if (!path || !path[0]) return NULL;
-    return fopen(path, "a");
-}
-
-static void metalbear_log(metalbear_log_level level, const char *fmt, ...) {
-    if (level < log_level) return;
-    static const char *level_names[] = {"DEBUG", "INFO", "WARN", "ERROR"};
-    va_list args;
-    FILE *out = log_file ? log_file : stderr;
-    time_t now = time(NULL);
-    struct tm tm;
-#if defined(__APPLE__)
-    localtime_r(&now, &tm);
-#else
-    localtime_r(&now, &tm);
-#endif
-    char ts[32];
-    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm);
-    fprintf(out, "MetalBear [%s] [%s] ", level_names[level], ts);
-    va_start(args, fmt);
-    vfprintf(out, fmt, args);
-    va_end(args);
-    fprintf(out, "\n");
-    if (log_file) fflush(log_file);
-}
-
-#define LOG_DEBUG(...) metalbear_log(METALBEAR_LOG_DEBUG, __VA_ARGS__)
-#define LOG_INFO(...) metalbear_log(METALBEAR_LOG_INFO, __VA_ARGS__)
-#define LOG_WARN(...) metalbear_log(METALBEAR_LOG_WARN, __VA_ARGS__)
-#define LOG_ERROR(...) metalbear_log(METALBEAR_LOG_ERROR, __VA_ARGS__)
+/* Logging lives in log.c so the daemon shares it: see metalbear/log.h. */
 
 static char *join_path(const char *directory, const char *name);
 
@@ -111,6 +59,8 @@ static bool admin_authenticated(metalbear_server *server,
 
 struct metalbear_server {
     wf_xrpc_server *xrpc;
+    /* When this process began serving, for the uptime gauge at /metrics. */
+    time_t started_at;
     /*
      * The server's own PLC rotation key and OAuth store.
      *
@@ -176,6 +126,7 @@ static void publish_handle_dns(metalbear_server *server, const char *handle,
                                const char *did) {
     if (!server->handle_dns || !handle || !did) return;
     if (metalbear_handle_dns_publish(server->handle_dns, handle, did) != WF_OK) {
+        metalbear_metrics_inc(METALBEAR_METRIC_DNS_FAILURES);
         LOG_ERROR("dns: could not publish _atproto.%s for did=%s: %s; the "
                   "handle will not resolve until the record exists",
                   handle, did,
@@ -190,6 +141,7 @@ static void publish_handle_dns(metalbear_server *server, const char *handle,
 static void retract_handle_dns(metalbear_server *server, const char *handle) {
     if (!server->handle_dns || !handle) return;
     if (metalbear_handle_dns_retract(server->handle_dns, handle) != WF_OK) {
+        metalbear_metrics_inc(METALBEAR_METRIC_DNS_FAILURES);
         LOG_WARN("dns: could not remove _atproto.%s: %s; the record now points "
                  "at a handle this host no longer serves",
                  handle, metalbear_handle_dns_last_error(server->handle_dns));
@@ -469,7 +421,22 @@ static bool full_access_route(const char *nsid) {
 /* Defined below alongside the other account-status helpers. */
 static bool account_is_taken_down(metalbear_server *server, const char *did);
 
+static wf_status authenticate_request(wf_xrpc_request *req, void *ctx);
+
+/*
+ * Wraps the auth callback purely to count. It is the one place every XRPC
+ * request passes through, public routes included, and wrapping it means a
+ * refusal added later cannot forget to be counted — which is the whole value
+ * of the rejected/total ratio as a signal.
+ */
 static wf_status authenticate(wf_xrpc_request *req, void *ctx) {
+    metalbear_metrics_inc(METALBEAR_METRIC_XRPC_REQUESTS);
+    wf_status status = authenticate_request(req, ctx);
+    if (status != WF_OK) metalbear_metrics_inc(METALBEAR_METRIC_XRPC_REJECTED);
+    return status;
+}
+
+static wf_status authenticate_request(wf_xrpc_request *req, void *ctx) {
     metalbear_server *server = ctx;
     LOG_DEBUG("authenticate: nsid=%s method=%s host=%s auth=%s",
               req->nsid ? req->nsid : "-",
@@ -746,6 +713,7 @@ static wf_status delete_account(void *ctx, const wf_xrpc_request *request,
                                        "deleted");
     int64_t purged = 0;
     metalbear_sequencer_purge_account(server->sequencer, acct->did, &purged);
+    metalbear_metrics_inc(METALBEAR_METRIC_ACCOUNTS_DELETED);
     LOG_INFO("delete_account: purged %lld firehose events for did=%s",
              (long long)purged, acct->did);
     /* Drop the handle's TXT record: leaving it would keep pointing resolvers
@@ -1840,6 +1808,7 @@ static wf_status create_session(void *ctx, const wf_xrpc_request *request,
     if (credential == METALBEAR_CREDENTIAL_INVALID || !acct) {
         LOG_WARN("create_session: invalid credentials for host=%s",
                  request->host_header ? request->host_header : "(unknown)");
+        metalbear_metrics_inc(METALBEAR_METRIC_LOGIN_FAILURES);
         wf_xrpc_response_set_error(response, 401, "AuthenticationRequired",
                                    "Invalid identifier or password");
         return WF_OK;
@@ -1851,6 +1820,7 @@ static wf_status create_session(void *ctx, const wf_xrpc_request *request,
      */
     if (account_is_taken_down(server, acct->did)) {
         free(app_password_name);
+        metalbear_metrics_inc(METALBEAR_METRIC_LOGIN_FAILURES);
         LOG_WARN("create_session: refused taken-down account did=%s", acct->did);
         wf_xrpc_response_set_error(response, 401, "AccountTakedown",
                                    "Account has been taken down");
@@ -1871,6 +1841,7 @@ static wf_status create_session(void *ctx, const wf_xrpc_request *request,
         return WF_OK;
     }
     free(app_password_name);
+    metalbear_metrics_inc(METALBEAR_METRIC_SESSIONS_CREATED);
     LOG_INFO("create_session: issued session for did=%s scope=%d", acct->did, scope);
     wf_status status = set_json(response, session_json(server, acct, &tokens));
     metalbear_session_tokens_free(&tokens);
@@ -3710,6 +3681,7 @@ static wf_status create_account(void *ctx, const wf_xrpc_request *request,
         return WF_OK;
     }
 
+    metalbear_metrics_inc(METALBEAR_METRIC_ACCOUNTS_CREATED);
     LOG_INFO("create_account: created handle=%s did=%s email=%s",
              handle->valuestring, account_did, email->valuestring);
 
@@ -4534,6 +4506,7 @@ static wf_status admin_update_subject_status(void *ctx,
          * effect on the tokens already issued rather than only on new logins.
          * Lifting it does not restore them: the holder logs in again.
          */
+        if (applying) metalbear_metrics_inc(METALBEAR_METRIC_TAKEDOWNS_APPLIED);
         if (account_subject && applying) {
             metalbear_account_context *acct = context_for_did(server, did);
             if (acct) metalbear_auth_delete_all(acct->auth);
@@ -5070,6 +5043,7 @@ static wf_status admin_delete_account(void *ctx,
     int64_t purged = 0;
     metalbear_sequencer_purge_account(server->sequencer, did->valuestring,
                                       &purged);
+    metalbear_metrics_inc(METALBEAR_METRIC_ACCOUNTS_DELETED);
     LOG_INFO("admin_delete_account: purged %lld firehose events for did=%s",
              (long long)purged, did->valuestring);
 
@@ -5141,11 +5115,13 @@ static void *crawler_notify_main(void *raw) {
             wf_response up = {0};
             wf_status st = wf_xrpc_procedure(
                 client, "com.atproto.sync.requestCrawl", n->body, &up);
-            if (st != WF_OK || up.status < 200 || up.status >= 300)
+            if (st != WF_OK || up.status < 200 || up.status >= 300) {
+                metalbear_metrics_inc(METALBEAR_METRIC_CRAWL_FAILURES);
                 LOG_WARN("requestCrawl to %s failed (status %ld)", host,
                          (long)up.status);
-            else
+            } else {
                 LOG_INFO("announced new data to %s", host);
+            }
             wf_response_free(&up);
             wf_xrpc_client_free(client);
         }
@@ -5790,6 +5766,7 @@ static wf_status upload_blob(void *ctx, const wf_xrpc_request *request,
                                     "failed to store blob");
         return WF_OK;
     }
+    metalbear_metrics_inc(METALBEAR_METRIC_BLOBS_UPLOADED);
     cJSON *root = cJSON_CreateObject();
     cJSON *blob = cJSON_CreateObject();
     if (!root || !blob) {
@@ -6318,6 +6295,97 @@ static wf_status tls_check_handler(void *ctx, const wf_xrpc_request *req,
     return WF_OK;
 }
 
+/* ---- GET /metrics (Prometheus text format, admin-gated) ----
+ *
+ * Counters come from the metrics table; everything describing the host's
+ * current state is read from the real thing here rather than mirrored into a
+ * gauge, because a mirrored gauge is a second copy of the truth and drifts
+ * from the first.
+ *
+ * Behind the admin password. An open endpoint would publish the account count
+ * and the write rate of a private host to anyone who asked, and hand an
+ * unauthenticated caller an unbounded amount of work per request. Prometheus
+ * has had basic_auth in its scrape config for as long as it has existed.
+ */
+static wf_status metrics_handler(void *ctx, const wf_xrpc_request *req,
+                                 wf_xrpc_response *resp) {
+    metalbear_server *server = ctx;
+    if (!admin_authenticated(server, req)) {
+        wf_xrpc_response_set_error(resp, 401, "AuthenticationRequired",
+                                   "Authentication required");
+        return WF_OK;
+    }
+
+    sb_t sb = {0};
+    bool ok = sb_append(&sb,
+        "# HELP metalbear_build_info Version of the running server.\n"
+        "# TYPE metalbear_build_info gauge\n"
+        "metalbear_build_info{version=\"%s\"} 1\n", METALBEAR_VERSION);
+
+    for (int i = 0; ok && i < METALBEAR_METRIC_COUNT; i++) {
+        const char *name = metalbear_metric_name(i);
+        const char *help = metalbear_metric_help(i);
+        if (!name) continue;
+        ok = sb_append(&sb,
+                       "# HELP metalbear_%s %s\n"
+                       "# TYPE metalbear_%s counter\n"
+                       "metalbear_%s %llu\n",
+                       name, help ? help : "", name, name,
+                       (unsigned long long)metalbear_metrics_get(i));
+    }
+
+    /* Account counts, read from the registry at scrape time. */
+    size_t total = 0, active = 0, taken_down = 0;
+    metalbear_account_entry *entries = NULL;
+    size_t count = 0;
+    if (metalbear_account_registry_list(server->registry, &entries,
+                                        &count) == WF_OK) {
+        total = count;
+        for (size_t i = 0; i < count; i++) {
+            if (account_is_taken_down(server, entries[i].did)) taken_down++;
+            else if (entries[i].active) active++;
+        }
+        metalbear_account_entries_free(entries, count);
+    }
+    if (ok)
+        ok = sb_append(&sb,
+            "# HELP metalbear_accounts Accounts on this host by status.\n"
+            "# TYPE metalbear_accounts gauge\n"
+            "metalbear_accounts{status=\"active\"} %zu\n"
+            "metalbear_accounts{status=\"inactive\"} %zu\n"
+            "metalbear_accounts{status=\"takendown\"} %zu\n",
+            active, total - active - taken_down, taken_down);
+
+    /*
+     * The firehose cursor. A relay that has stopped consuming shows up as this
+     * climbing while nothing downstream moves, and it is the single number
+     * worth alerting on: a PDS whose sequence has stalled is one nobody can
+     * tell apart from a PDS that is down.
+     */
+    if (ok)
+        ok = sb_append(&sb,
+            "# HELP metalbear_firehose_seq Most recent firehose sequence number.\n"
+            "# TYPE metalbear_firehose_seq gauge\n"
+            "metalbear_firehose_seq %lld\n",
+            (long long)metalbear_sequencer_current(server->sequencer));
+
+    if (ok)
+        ok = sb_append(&sb,
+            "# HELP metalbear_uptime_seconds Seconds since this process began serving.\n"
+            "# TYPE metalbear_uptime_seconds gauge\n"
+            "metalbear_uptime_seconds %lld\n",
+            (long long)(time(NULL) - server->started_at));
+
+    if (!ok) {
+        free(sb.buf);
+        return WF_ERR_ALLOC;
+    }
+    wf_xrpc_response_set_content_type(resp, "text/plain; version=0.0.4");
+    wf_xrpc_response_set_body(resp, sb.buf, sb.len);
+    free(sb.buf);
+    return WF_OK;
+}
+
 static wf_status landing_handler(void *ctx, const wf_xrpc_request *req,
                                  wf_xrpc_response *resp) {
     (void)req;
@@ -6713,6 +6781,9 @@ static wf_status register_identity_documents(metalbear_server *server) {
     status = wf_xrpc_server_register_http_prefix(server->xrpc, "GET", "/acct/",
                                                  handle_account_did_web, server);
     if (status != WF_OK) return status;
+    status = wf_xrpc_server_register_http_route(server->xrpc, "GET", "/metrics",
+                                                metrics_handler, server);
+    if (status != WF_OK) return status;
     status = wf_xrpc_server_register_http_route(server->xrpc, "GET", "/",
                                                 landing_handler, server);
     if (status != WF_OK) return status;
@@ -6772,8 +6843,7 @@ static bool valid_config(const metalbear_config *config) {
 }
 
 metalbear_server *metalbear_server_start(const metalbear_config *config) {
-    log_level = metalbear_log_level_from_env();
-    log_file = metalbear_log_file_from_env();
+    metalbear_log_configure();
     if (!valid_config(config)) {
         LOG_ERROR("invalid server configuration");
         return NULL;
@@ -6784,6 +6854,7 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
     }
 
     metalbear_server *server = calloc(1, sizeof(*server));
+    if (server) server->started_at = time(NULL);
     if (!server || !copy_config(server, config)) {
         LOG_ERROR("cannot initialise server");
         goto fail;
@@ -7364,10 +7435,7 @@ void metalbear_server_free(metalbear_server *server) {
     metalbear_handle_dns_free(server->handle_dns);
     metalbear_report_store_free(server->reports);
     wf_rate_limiter_free(server->rate_limiter);
-    if (log_file) {
-        fclose(log_file);
-        log_file = NULL;
-    }
+    metalbear_log_close();
     free(server->service_did);
     free(server->public_url);
     free(server->user_domain);

--- a/test/test_handle_dns.c
+++ b/test/test_handle_dns.c
@@ -5,9 +5,15 @@
  *
  * The publisher writes to a live DNS zone, so what matters is that it sends
  * exactly the right requests and never sends a wrong one. These tests run it
- * against a stand-in for the Cloudflare API that records everything it
- * receives, which is the only way to assert on requests that would otherwise
- * only be visible in someone's production zone.
+ * against a stand-in API that records everything it receives, which is the
+ * only way to assert on requests that would otherwise only be visible in
+ * someone's production zone.
+ *
+ * The stand-in speaks all three providers' dialects, because that is where
+ * they differ: Cloudflare reports a rejection as 200 with `success: false`,
+ * DigitalOcean uses integer record ids and answers a delete with a bodiless
+ * 204, and deSEC has no individual records at all — a name and type are one
+ * RRset, TXT content is quoted, and absence is a 404.
  */
 
 #include "metalbear/handle_dns.h"
@@ -37,10 +43,15 @@ typedef struct {
     char auth[512];
 } call;
 
+typedef enum { FLAVOUR_CLOUDFLARE, FLAVOUR_DIGITALOCEAN, FLAVOUR_DESEC }
+    flavour;
+
 static struct {
     pthread_mutex_t lock;
     call calls[MAX_CALLS];
     int count;
+    /* Which provider's dialect the stand-in answers in. */
+    flavour flavour;
     /* The record the zone currently holds, if any. */
     int has_record;
     char record_content[256];
@@ -111,38 +122,108 @@ static enum MHD_Result handler(void *cls, struct MHD_Connection *conn,
                                                    "Authorization");
     record_call(method, full, up->body, auth);
 
-    if (zone.reject)
+    if (zone.reject) {
+        if (zone.flavour == FLAVOUR_CLOUDFLARE)
+            return send_json(conn, 403,
+                             "{\"success\":false,\"errors\":"
+                             "[{\"code\":10000,"
+                             "\"message\":\"Authentication error\"}]}");
+        if (zone.flavour == FLAVOUR_DIGITALOCEAN)
+            return send_json(conn, 401,
+                             "{\"id\":\"unauthorized\","
+                             "\"message\":\"Authentication error\"}");
         return send_json(conn, 403,
-                         "{\"success\":false,\"errors\":"
-                         "[{\"code\":10000,\"message\":\"Authentication error\"}]}");
+                         "{\"detail\":\"Authentication error\"}");
+    }
 
     if (strcmp(method, "GET") == 0) {
-        if (zone.has_record) {
-            char body[512];
+        char body[512];
+        switch (zone.flavour) {
+        case FLAVOUR_CLOUDFLARE:
+            if (!zone.has_record)
+                return send_json(conn, 200, "{\"success\":true,\"result\":[]}");
             snprintf(body, sizeof(body),
                      "{\"success\":true,\"result\":[{\"id\":\"rec123\","
                      "\"content\":\"%s\"}]}", zone.record_content);
             return send_json(conn, 200, body);
+        case FLAVOUR_DIGITALOCEAN:
+            if (!zone.has_record)
+                return send_json(conn, 200, "{\"domain_records\":[]}");
+            snprintf(body, sizeof(body),
+                     "{\"domain_records\":[{\"id\":42,\"type\":\"TXT\","
+                     "\"data\":\"%s\"}]}", zone.record_content);
+            return send_json(conn, 200, body);
+        case FLAVOUR_DESEC:
+            /* Absence is a 404 here, not an empty list. */
+            if (!zone.has_record)
+                return send_json(conn, 404, "{\"detail\":\"Not found.\"}");
+            snprintf(body, sizeof(body),
+                     "{\"subname\":\"_atproto.x\",\"type\":\"TXT\","
+                     "\"ttl\":3600,\"records\":[\"\\\"%s\\\"\"]}",
+                     zone.record_content);
+            return send_json(conn, 200, body);
         }
-        return send_json(conn, 200, "{\"success\":true,\"result\":[]}");
     }
 
-    if (strcmp(method, "POST") == 0 || strcmp(method, "PATCH") == 0) {
+    if (strcmp(method, "POST") == 0 || strcmp(method, "PATCH") == 0 ||
+        strcmp(method, "PUT") == 0) {
         cJSON *doc = cJSON_Parse(up->body ? up->body : "");
-        cJSON *content = doc ? cJSON_GetObjectItemCaseSensitive(doc, "content")
-                             : NULL;
-        if (cJSON_IsString(content)) {
+        /* Each provider names the TXT value differently, and deSEC replaces
+         * the whole RRset — an empty list there is a delete. */
+        const char *value = NULL;
+        char unquoted[256];
+        if (doc && zone.flavour == FLAVOUR_CLOUDFLARE) {
+            cJSON *c = cJSON_GetObjectItemCaseSensitive(doc, "content");
+            if (cJSON_IsString(c)) value = c->valuestring;
+        } else if (doc && zone.flavour == FLAVOUR_DIGITALOCEAN) {
+            cJSON *c = cJSON_GetObjectItemCaseSensitive(doc, "data");
+            if (cJSON_IsString(c)) value = c->valuestring;
+        } else if (doc) {
+            cJSON *records = cJSON_GetObjectItemCaseSensitive(doc, "records");
+            if (cJSON_IsArray(records) && cJSON_GetArraySize(records) == 0) {
+                zone.has_record = 0;
+                cJSON_Delete(doc);
+                return send_json(conn, 200, "{\"records\":[]}");
+            }
+            cJSON *first = cJSON_IsArray(records)
+                ? cJSON_GetArrayItem(records, 0) : NULL;
+            if (cJSON_IsString(first)) {
+                size_t len = strlen(first->valuestring);
+                if (len >= 2 && first->valuestring[0] == '"') {
+                    snprintf(unquoted, sizeof(unquoted), "%.*s",
+                             (int)(len - 2), first->valuestring + 1);
+                    value = unquoted;
+                } else {
+                    value = first->valuestring;
+                }
+            }
+        }
+        if (value) {
             zone.has_record = 1;
             snprintf(zone.record_content, sizeof(zone.record_content), "%s",
-                     content->valuestring);
+                     value);
         }
         cJSON_Delete(doc);
-        return send_json(conn, 200,
-                         "{\"success\":true,\"result\":{\"id\":\"rec123\"}}");
+        if (zone.flavour == FLAVOUR_CLOUDFLARE)
+            return send_json(conn, 200,
+                             "{\"success\":true,\"result\":{\"id\":\"rec123\"}}");
+        if (zone.flavour == FLAVOUR_DIGITALOCEAN)
+            return send_json(conn, 201,
+                             "{\"domain_record\":{\"id\":42}}");
+        return send_json(conn, 200, "{\"records\":[]}");
     }
 
     if (strcmp(method, "DELETE") == 0) {
         zone.has_record = 0;
+        if (zone.flavour == FLAVOUR_DIGITALOCEAN) {
+            /* 204, with no body at all — an absent document must not be read
+             * as a failure. */
+            struct MHD_Response *res = MHD_create_response_from_buffer(
+                0, (void *)"", MHD_RESPMEM_PERSISTENT);
+            enum MHD_Result rc = MHD_queue_response(conn, 204, res);
+            MHD_destroy_response(res);
+            return rc;
+        }
         return send_json(conn, 200,
                          "{\"success\":true,\"result\":{\"id\":\"rec123\"}}");
     }
@@ -158,14 +239,17 @@ static void free_upload(void *cls, struct MHD_Connection *conn, void **con_cls,
     *con_cls = NULL;
 }
 
-static void zone_reset(void) {
+static void zone_reset_as(flavour which) {
     pthread_mutex_lock(&zone.lock);
     zone.count = 0;
     zone.has_record = 0;
     zone.reject = 0;
+    zone.flavour = which;
     zone.record_content[0] = '\0';
     pthread_mutex_unlock(&zone.lock);
 }
+
+static void zone_reset(void) { zone_reset_as(FLAVOUR_CLOUDFLARE); }
 
 static int call_count(void) {
     pthread_mutex_lock(&zone.lock);
@@ -353,6 +437,211 @@ static void test_bad_arguments(void) {
     metalbear_handle_dns_free(dns);
 }
 
+/* ------------------------------------------------------------------ */
+/* DigitalOcean                                                        */
+/* ------------------------------------------------------------------ */
+
+static metalbear_handle_dns *open_digitalocean(void) {
+    metalbear_handle_dns *dns = NULL;
+    CHECK(metalbear_handle_dns_open("digitalocean", "do-token", "example.com",
+                                    120, &dns) == WF_OK);
+    return dns;
+}
+
+/*
+ * The zone is addressed by domain name rather than an opaque id, the TXT value
+ * is `data` rather than `content`, and the name is sent fully qualified with a
+ * trailing dot — without it the API appends the domain to a name that already
+ * ends with it and the record lands at `_atproto.alice.example.com.example.com`.
+ */
+static void test_digitalocean_publish_creates_the_record(void) {
+    zone_reset_as(FLAVOUR_DIGITALOCEAN);
+    metalbear_handle_dns *dns = open_digitalocean();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_publish(dns, "alice.example.com",
+                                       "did:plc:alice") == WF_OK);
+    CHECK(call_count() == 2);
+    CHECK(strcmp(zone.calls[0].method, "GET") == 0);
+    CHECK(strstr(zone.calls[0].url, "/domains/example.com/records") != NULL);
+    CHECK(strcmp(zone.calls[1].method, "POST") == 0);
+    CHECK(strstr(zone.calls[1].body, "\"data\":\"did=did:plc:alice\"") != NULL);
+    CHECK(strstr(zone.calls[1].body,
+                 "\"name\":\"_atproto.alice.example.com.\"") != NULL);
+    CHECK(strcmp(zone.calls[1].auth, "Bearer do-token") == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* Record ids are integers, and the update has to put one back into the URL. */
+static void test_digitalocean_updates_by_integer_id(void) {
+    zone_reset_as(FLAVOUR_DIGITALOCEAN);
+    metalbear_handle_dns *dns = open_digitalocean();
+    if (!dns) return;
+
+    zone.has_record = 1;
+    snprintf(zone.record_content, sizeof(zone.record_content),
+             "did=did:plc:old");
+    CHECK(metalbear_handle_dns_publish(dns, "carol.example.com",
+                                       "did:plc:new") == WF_OK);
+    CHECK(call_count() == 2);
+    CHECK(strcmp(zone.calls[1].method, "PUT") == 0);
+    CHECK(strstr(zone.calls[1].url, "/records/42") != NULL);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* A delete answers 204 with no body. Requiring a parseable document — which
+ * Cloudflare's path does — would read every successful delete as a failure. */
+static void test_digitalocean_retract_accepts_a_bodiless_204(void) {
+    zone_reset_as(FLAVOUR_DIGITALOCEAN);
+    metalbear_handle_dns *dns = open_digitalocean();
+    if (!dns) return;
+
+    zone.has_record = 1;
+    snprintf(zone.record_content, sizeof(zone.record_content),
+             "did=did:plc:dave");
+    CHECK(metalbear_handle_dns_retract(dns, "dave.example.com") == WF_OK);
+    CHECK(call_count() == 2);
+    CHECK(strcmp(zone.calls[1].method, "DELETE") == 0);
+    CHECK(strstr(zone.calls[1].url, "/records/42") != NULL);
+    CHECK(zone.has_record == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+static void test_digitalocean_reports_a_rejection(void) {
+    zone_reset_as(FLAVOUR_DIGITALOCEAN);
+    metalbear_handle_dns *dns = open_digitalocean();
+    if (!dns) return;
+
+    zone.reject = 1;
+    CHECK(metalbear_handle_dns_publish(dns, "frank.example.com",
+                                       "did:plc:frank") != WF_OK);
+    CHECK(strstr(metalbear_handle_dns_last_error(dns), "Authentication error")
+          != NULL);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* ------------------------------------------------------------------ */
+/* deSEC                                                               */
+/* ------------------------------------------------------------------ */
+
+static metalbear_handle_dns *open_desec(void) {
+    metalbear_handle_dns *dns = NULL;
+    CHECK(metalbear_handle_dns_open("desec", "desec-token", "example.com",
+                                    120, &dns) == WF_OK);
+    return dns;
+}
+
+/*
+ * An RRset, addressed by the name relative to the domain, replaced wholesale
+ * with a PUT — so there is no create/update distinction to get wrong. TXT
+ * content is stored in presentation format, quotes included, and a value
+ * written bare would resolve to a DID with quotation marks in it.
+ *
+ * `Token`, not `Bearer`: deSEC rejects the OAuth scheme outright.
+ */
+static void test_desec_publish_replaces_the_rrset(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_publish(dns, "alice.example.com",
+                                       "did:plc:alice") == WF_OK);
+    CHECK(call_count() == 2);
+    CHECK(strcmp(zone.calls[0].method, "GET") == 0);
+    CHECK(strstr(zone.calls[0].url,
+                 "/domains/example.com/rrsets/_atproto.alice/TXT/") != NULL);
+    CHECK(strcmp(zone.calls[1].method, "PUT") == 0);
+    CHECK(strstr(zone.calls[1].body, "\\\"did=did:plc:alice\\\"") != NULL);
+    CHECK(strstr(zone.calls[1].body, "\"subname\":\"_atproto.alice\"") != NULL);
+    CHECK(strcmp(zone.calls[1].auth, "Token desec-token") == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* deSEC refuses a TTL under an hour. Passing the configured 120 through would
+ * fail every write; raising it to the floor keeps handles resolving. */
+static void test_desec_raises_a_ttl_below_the_floor(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_publish(dns, "alice.example.com",
+                                       "did:plc:alice") == WF_OK);
+    CHECK(strstr(zone.calls[1].body, "\"ttl\":3600") != NULL);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* The stored value comes back quoted, and comparing it to the bare one we
+ * want would rewrite the RRset on every reconciliation. */
+static void test_desec_publish_is_idempotent_through_the_quoting(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_publish(dns, "bob.example.com",
+                                       "did:plc:bob") == WF_OK);
+    int after_first = call_count();
+    CHECK(metalbear_handle_dns_publish(dns, "bob.example.com",
+                                       "did:plc:bob") == WF_OK);
+    CHECK(call_count() == after_first + 1);
+    CHECK(strcmp(zone.calls[after_first].method, "GET") == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* Removal is a PUT of an empty record list, not a DELETE. */
+static void test_desec_retract_empties_the_rrset(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    zone.has_record = 1;
+    snprintf(zone.record_content, sizeof(zone.record_content),
+             "did=did:plc:dave");
+    CHECK(metalbear_handle_dns_retract(dns, "dave.example.com") == WF_OK);
+    CHECK(call_count() == 2);
+    CHECK(strcmp(zone.calls[1].method, "PUT") == 0);
+    CHECK(strstr(zone.calls[1].body, "\"records\":[]") != NULL);
+    CHECK(zone.has_record == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* A missing RRset is a 404, which must read as "no record" rather than as a
+ * failed lookup — otherwise the first account on a fresh domain never gets
+ * one written. */
+static void test_desec_absent_rrset_is_not_an_error(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_retract(dns, "erin.example.com") == WF_OK);
+    CHECK(call_count() == 1);
+    CHECK(strcmp(zone.calls[0].method, "GET") == 0);
+
+    metalbear_handle_dns_free(dns);
+}
+
+/* A handle outside the configured domain cannot be expressed as a subname, and
+ * must be refused rather than sent as something the API will misplace. */
+static void test_desec_rejects_a_name_outside_the_domain(void) {
+    zone_reset_as(FLAVOUR_DESEC);
+    metalbear_handle_dns *dns = open_desec();
+    if (!dns) return;
+
+    CHECK(metalbear_handle_dns_publish(dns, "alice.elsewhere.test",
+                                       "did:plc:alice") != WF_OK);
+    CHECK(call_count() == 0);
+    CHECK(strstr(metalbear_handle_dns_last_error(dns), "example.com") != NULL);
+
+    metalbear_handle_dns_free(dns);
+}
+
 int main(void) {
     printf("MetalBear handle DNS tests\n");
     pthread_mutex_init(&zone.lock, NULL);
@@ -378,6 +667,16 @@ int main(void) {
     test_retract_removes_the_record();
     test_retract_of_an_absent_record_succeeds();
     test_a_rejected_request_is_a_failure();
+    test_digitalocean_publish_creates_the_record();
+    test_digitalocean_updates_by_integer_id();
+    test_digitalocean_retract_accepts_a_bodiless_204();
+    test_digitalocean_reports_a_rejection();
+    test_desec_publish_replaces_the_rrset();
+    test_desec_raises_a_ttl_below_the_floor();
+    test_desec_publish_is_idempotent_through_the_quoting();
+    test_desec_retract_empties_the_rrset();
+    test_desec_absent_rrset_is_not_an_error();
+    test_desec_rejects_a_name_outside_the_domain();
     test_bad_arguments();
 
     MHD_stop_daemon(stub);

--- a/test/test_handle_dns_rfc2136.c
+++ b/test/test_handle_dns_rfc2136.c
@@ -1,0 +1,427 @@
+#define _POSIX_C_SOURCE 200809L
+#define _DARWIN_C_SOURCE
+
+/*
+ * test_handle_dns_rfc2136.c — TSIG-signed dynamic DNS update.
+ *
+ * The update is a wire format sent to somebody else's nameserver, so the only
+ * thing worth asserting is what actually goes down the socket. These tests run
+ * the publisher against a stand-in nameserver that parses the message and
+ * recomputes the TSIG MAC from scratch — deliberately not by calling the
+ * signing code, since verifying our encoder with our encoder proves nothing.
+ * A signature that is wrong in a way both sides share is exactly the defect
+ * that makes every update fail against a real server while the suite is green.
+ */
+
+#include "metalbear/handle_dns.h"
+#include "metalbear/handle_dns_rfc2136.h"
+
+#include <openssl/hmac.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int failures;
+#define CHECK(expr) do { if (!(expr)) { \
+    fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    failures++; } } while (0)
+
+/* The key both sides share. "secret bytes here!!" in base64. */
+static const char *KEY_NAME = "metalbear-key";
+static const unsigned char KEY_SECRET[] = "secret bytes here!!";
+#define KEY_SECRET_LEN (sizeof(KEY_SECRET) - 1)
+
+/* ------------------------------------------------------------------ */
+/* A stand-in nameserver                                               */
+/* ------------------------------------------------------------------ */
+
+static struct {
+    int listen_fd;
+    unsigned short port;
+    pthread_t thread;
+    /* What the last request contained, for the assertions. */
+    unsigned char request[4096];
+    size_t request_len;
+    bool tsig_verified;
+    bool is_update;
+    unsigned rcode_to_send;
+    /* A TXT value to answer a query with, or "" for none. */
+    char answer[256];
+    int served;
+} ns;
+
+/* Skip a wire-format name, returning the offset just past it. */
+static size_t skip_name(const unsigned char *buf, size_t len, size_t at) {
+    while (at < len && buf[at] != 0) {
+        if ((buf[at] & 0xc0) == 0xc0) return at + 2;
+        at += buf[at] + 1;
+    }
+    return at + 1;
+}
+
+/*
+ * Recompute the MAC over the request and compare it with the one the TSIG
+ * record carries.
+ *
+ * The digest covers the message up to the TSIG record with ARCOUNT reduced by
+ * one — the count as it stood before the record was appended — followed by the
+ * TSIG variables. Reconstructing that here, from the bytes on the wire, is
+ * what makes this an independent check rather than a restatement.
+ */
+static bool verify_tsig(const unsigned char *msg, size_t len) {
+    if (len < 12) return false;
+    unsigned qdcount = (unsigned)((msg[4] << 8) | msg[5]);
+    unsigned ancount = (unsigned)((msg[6] << 8) | msg[7]);
+    unsigned nscount = (unsigned)((msg[8] << 8) | msg[9]);
+    unsigned arcount = (unsigned)((msg[10] << 8) | msg[11]);
+    if (arcount == 0) return false;
+
+    size_t at = 12;
+    for (unsigned i = 0; i < qdcount; i++) {
+        at = skip_name(msg, len, at);
+        at += 4;
+    }
+    /* Answer and authority sections carry full records. */
+    for (unsigned i = 0; i < ancount + nscount; i++) {
+        at = skip_name(msg, len, at);
+        if (at + 10 > len) return false;
+        unsigned rdlength = (unsigned)((msg[at + 8] << 8) | msg[at + 9]);
+        at += 10 + rdlength;
+    }
+    /* Additional records before the TSIG, which must be last. */
+    for (unsigned i = 0; i + 1 < arcount; i++) {
+        at = skip_name(msg, len, at);
+        if (at + 10 > len) return false;
+        unsigned rdlength = (unsigned)((msg[at + 8] << 8) | msg[at + 9]);
+        at += 10 + rdlength;
+    }
+    size_t tsig_at = at;
+    if (tsig_at >= len) return false;
+
+    /* The TSIG record itself. */
+    size_t name_start = at;
+    at = skip_name(msg, len, at);
+    size_t name_len = at - name_start;
+    if (at + 10 > len) return false;
+    unsigned type = (unsigned)((msg[at] << 8) | msg[at + 1]);
+    if (type != 250) return false;
+    at += 10;
+    size_t rdata_at = at;
+    size_t algo_start = at;
+    at = skip_name(msg, len, at);
+    size_t algo_len = at - algo_start;
+    if (at + 10 > len) return false;
+    const unsigned char *time_signed = msg + at;   /* 6 bytes */
+    const unsigned char *fudge = msg + at + 6;     /* 2 bytes */
+    unsigned mac_len = (unsigned)((msg[at + 8] << 8) | msg[at + 9]);
+    at += 10;
+    if (at + mac_len > len) return false;
+    const unsigned char *mac = msg + at;
+    (void)rdata_at;
+
+    /* The message as it was when signed: everything before the TSIG, with
+     * ARCOUNT one lower. */
+    unsigned char signed_copy[4096];
+    if (tsig_at > sizeof(signed_copy)) return false;
+    memcpy(signed_copy, msg, tsig_at);
+    unsigned before = arcount - 1;
+    signed_copy[10] = (unsigned char)(before >> 8);
+    signed_copy[11] = (unsigned char)before;
+
+    unsigned char vars[512];
+    size_t v = 0;
+    memcpy(vars + v, msg + name_start, name_len); v += name_len;
+    vars[v++] = 0x00; vars[v++] = 0xff;            /* class ANY */
+    vars[v++] = 0; vars[v++] = 0; vars[v++] = 0; vars[v++] = 0;  /* TTL 0 */
+    memcpy(vars + v, msg + algo_start, algo_len); v += algo_len;
+    memcpy(vars + v, time_signed, 6); v += 6;
+    memcpy(vars + v, fudge, 2); v += 2;
+    vars[v++] = 0; vars[v++] = 0;                  /* error */
+    vars[v++] = 0; vars[v++] = 0;                  /* other len */
+
+    unsigned char expected[EVP_MAX_MD_SIZE];
+    unsigned int expected_len = 0;
+    HMAC_CTX *ctx = HMAC_CTX_new();
+    if (!ctx) return false;
+    bool ok = HMAC_Init_ex(ctx, KEY_SECRET, (int)KEY_SECRET_LEN,
+                           EVP_sha256(), NULL) == 1 &&
+              HMAC_Update(ctx, signed_copy, tsig_at) == 1 &&
+              HMAC_Update(ctx, vars, v) == 1 &&
+              HMAC_Final(ctx, expected, &expected_len) == 1;
+    HMAC_CTX_free(ctx);
+    if (!ok) return false;
+    return expected_len == mac_len && memcmp(expected, mac, mac_len) == 0;
+}
+
+static void *serve(void *arg) {
+    (void)arg;
+    for (;;) {
+        int fd = accept(ns.listen_fd, NULL, NULL);
+        if (fd < 0) return NULL;
+
+        unsigned char prefix[2];
+        size_t got = 0;
+        while (got < 2) {
+            ssize_t n = recv(fd, prefix + got, 2 - got, 0);
+            if (n <= 0) break;
+            got += (size_t)n;
+        }
+        if (got != 2) { close(fd); continue; }
+        size_t want = (size_t)((prefix[0] << 8) | prefix[1]);
+        if (want > sizeof(ns.request)) { close(fd); continue; }
+        got = 0;
+        while (got < want) {
+            ssize_t n = recv(fd, ns.request + got, want - got, 0);
+            if (n <= 0) break;
+            got += (size_t)n;
+        }
+        if (got != want) { close(fd); continue; }
+        ns.request_len = got;
+        ns.tsig_verified = verify_tsig(ns.request, ns.request_len);
+        ns.is_update = ((ns.request[2] >> 3) & 0x0f) == 5;
+        ns.served++;
+
+        /* A minimal reply: the request's header, flipped to a response, with
+         * the configured RCODE and — for a query — one TXT answer. */
+        unsigned char reply[1024];
+        size_t rl = 12;
+        memcpy(reply, ns.request, 12);
+        reply[2] = (unsigned char)(ns.request[2] | 0x80);
+        reply[3] = (unsigned char)ns.rcode_to_send;
+        reply[6] = 0; reply[7] = 0;      /* ANCOUNT */
+        reply[8] = 0; reply[9] = 0;
+        reply[10] = 0; reply[11] = 0;
+
+        if (!ns.is_update) {
+            /* Echo the question, then answer it if a value is configured. */
+            size_t qend = skip_name(ns.request, ns.request_len, 12) + 4;
+            memcpy(reply + rl, ns.request + 12, qend - 12);
+            rl += qend - 12;
+            if (ns.answer[0]) {
+                size_t value_len = strlen(ns.answer);
+                memcpy(reply + rl, ns.request + 12, qend - 12 - 4);
+                rl += qend - 12 - 4;
+                reply[rl++] = 0; reply[rl++] = 16;      /* TXT */
+                reply[rl++] = 0; reply[rl++] = 1;       /* IN */
+                reply[rl++] = 0; reply[rl++] = 0;
+                reply[rl++] = 0; reply[rl++] = 60;      /* TTL */
+                reply[rl++] = 0;
+                reply[rl++] = (unsigned char)(value_len + 1);
+                reply[rl++] = (unsigned char)value_len;
+                memcpy(reply + rl, ns.answer, value_len);
+                rl += value_len;
+                reply[6] = 0; reply[7] = 1;
+            }
+        }
+        unsigned char out_prefix[2] = { (unsigned char)(rl >> 8),
+                                        (unsigned char)rl };
+        send(fd, out_prefix, 2, 0);
+        send(fd, reply, rl, 0);
+        close(fd);
+    }
+}
+
+static bool start_nameserver(void) {
+    ns.listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (ns.listen_fd < 0) return false;
+    int one = 1;
+    setsockopt(ns.listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    if (bind(ns.listen_fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+        return false;
+    socklen_t len = sizeof(addr);
+    if (getsockname(ns.listen_fd, (struct sockaddr *)&addr, &len) != 0)
+        return false;
+    ns.port = ntohs(addr.sin_port);
+    if (listen(ns.listen_fd, 4) != 0) return false;
+    return pthread_create(&ns.thread, NULL, serve, NULL) == 0;
+}
+
+/* ------------------------------------------------------------------ */
+
+static metalbear_handle_dns *open_publisher(void) {
+    char server[64];
+    snprintf(server, sizeof(server), "127.0.0.1:%u", (unsigned)ns.port);
+    /* "secret bytes here!!" base64-encoded, the form an operator copies out
+     * of a BIND key stanza. */
+    char credential[128];
+    snprintf(credential, sizeof(credential), "%s:%s", KEY_NAME,
+             "c2VjcmV0IGJ5dGVzIGhlcmUhIQ==");
+    metalbear_handle_dns *dns = NULL;
+    CHECK(metalbear_handle_dns_open_ex("rfc2136", credential, "example.com",
+                                       server, 300, &dns) == WF_OK);
+    return dns;
+}
+
+static void reset(void) {
+    ns.request_len = 0;
+    ns.tsig_verified = false;
+    ns.rcode_to_send = 0;
+    ns.answer[0] = '\0';
+    ns.served = 0;
+}
+
+/*
+ * The signature has to verify against a MAC computed independently. This is
+ * the whole test: three defects of this kind — the wrong ARCOUNT in the
+ * digest, an uncanonicalised key name, a missing algorithm name — all produce
+ * a message that looks correct and that no nameserver accepts.
+ */
+static void test_update_is_signed_correctly(void) {
+    reset();
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_publish(dns, "alice.example.com",
+                                       "did:plc:alice") == WF_OK);
+    /* A read and a write, both signed. */
+    CHECK(ns.served == 2);
+    CHECK(ns.tsig_verified);
+    CHECK(ns.is_update);
+    metalbear_handle_dns_free(dns);
+}
+
+/* The update must delete the RRset and add the new value in one message, or a
+ * reader between the two calls sees a handle with no record. */
+static void test_update_replaces_the_rrset(void) {
+    reset();
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_publish(dns, "alice.example.com",
+                                       "did:plc:alice") == WF_OK);
+    /* UPCOUNT of 2: the delete and the add. */
+    unsigned upcount = (unsigned)((ns.request[8] << 8) | ns.request[9]);
+    CHECK(upcount == 2);
+    /* And the value is in there, length-prefixed as TXT rdata. */
+    bool found = false;
+    const char *needle = "did=did:plc:alice";
+    size_t nlen = strlen(needle);
+    for (size_t i = 0; i + nlen <= ns.request_len; i++)
+        if (memcmp(ns.request + i, needle, nlen) == 0) found = true;
+    CHECK(found);
+    metalbear_handle_dns_free(dns);
+}
+
+/* A record already saying the right thing is left alone: the read happens
+ * first, and a match means no update at all. */
+static void test_publish_is_idempotent(void) {
+    reset();
+    snprintf(ns.answer, sizeof(ns.answer), "did=did:plc:bob");
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_publish(dns, "bob.example.com",
+                                       "did:plc:bob") == WF_OK);
+    CHECK(ns.served == 1);
+    CHECK(!ns.is_update);
+    metalbear_handle_dns_free(dns);
+}
+
+/* A stale record is corrected. */
+static void test_publish_updates_a_stale_record(void) {
+    reset();
+    snprintf(ns.answer, sizeof(ns.answer), "did=did:plc:old");
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_publish(dns, "carol.example.com",
+                                       "did:plc:new") == WF_OK);
+    CHECK(ns.served == 2);
+    CHECK(ns.is_update);
+    CHECK(ns.tsig_verified);
+    metalbear_handle_dns_free(dns);
+}
+
+/* Retract removes the RRset, and does so with an update carrying only the
+ * delete. */
+static void test_retract_deletes_the_rrset(void) {
+    reset();
+    snprintf(ns.answer, sizeof(ns.answer), "did=did:plc:dave");
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_retract(dns, "dave.example.com") == WF_OK);
+    CHECK(ns.served == 2);
+    CHECK(ns.is_update);
+    unsigned upcount = (unsigned)((ns.request[8] << 8) | ns.request[9]);
+    CHECK(upcount == 1);
+    metalbear_handle_dns_free(dns);
+}
+
+/* Absent already: nothing to delete, and no update sent. */
+static void test_retract_of_an_absent_record_sends_no_update(void) {
+    reset();
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_retract(dns, "erin.example.com") == WF_OK);
+    CHECK(ns.served == 1);
+    CHECK(!ns.is_update);
+    metalbear_handle_dns_free(dns);
+}
+
+/*
+ * A refused update must fail loudly and name the RCODE. NOTAUTH in particular
+ * almost always means the key is right and the server does not allow it to
+ * update that zone, which is a different thing for the operator to fix than a
+ * wrong key.
+ */
+static void test_a_refused_update_is_a_failure(void) {
+    reset();
+    ns.rcode_to_send = 9;   /* NOTAUTH */
+    metalbear_handle_dns *dns = open_publisher();
+    if (!dns) return;
+    CHECK(metalbear_handle_dns_publish(dns, "frank.example.com",
+                                       "did:plc:frank") != WF_OK);
+    CHECK(strstr(metalbear_handle_dns_last_error(dns), "NOTAUTH") != NULL);
+    metalbear_handle_dns_free(dns);
+}
+
+/*
+ * rfc2136 without a server has nowhere to send an update, and a key that is
+ * not `name:secret` cannot be used to sign one. Both are refused at open
+ * rather than accepted into a host that silently writes no records.
+ */
+static void test_incomplete_configuration_is_refused(void) {
+    metalbear_handle_dns *dns = NULL;
+    CHECK(metalbear_handle_dns_open_ex("rfc2136", "key:c2VjcmV0",
+                                       "example.com", NULL, 300, &dns)
+          != WF_OK);
+    CHECK(dns == NULL);
+    CHECK(metalbear_handle_dns_open_ex("rfc2136", "no-colon-here",
+                                       "example.com", "127.0.0.1", 300, &dns)
+          != WF_OK);
+    CHECK(dns == NULL);
+    /* And the plain open, which cannot supply a server, refuses it too. */
+    CHECK(metalbear_handle_dns_open("rfc2136", "key:c2VjcmV0", "example.com",
+                                    300, &dns) != WF_OK);
+    CHECK(dns == NULL);
+}
+
+int main(void) {
+    printf("MetalBear RFC 2136 handle DNS tests\n");
+    if (!start_nameserver()) {
+        fprintf(stderr, "could not start the stand-in nameserver\n");
+        return 1;
+    }
+
+    test_incomplete_configuration_is_refused();
+    test_update_is_signed_correctly();
+    test_update_replaces_the_rrset();
+    test_publish_is_idempotent();
+    test_publish_updates_a_stale_record();
+    test_retract_deletes_the_rrset();
+    test_retract_of_an_absent_record_sends_no_update();
+    test_a_refused_update_is_a_failure();
+
+    close(ns.listen_fd);
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("All tests passed.\n");
+    return 0;
+}

--- a/test/test_handle_dns_rfc2136.c
+++ b/test/test_handle_dns_rfc2136.c
@@ -144,17 +144,15 @@ static bool verify_tsig(const unsigned char *msg, size_t len) {
     vars[v++] = 0; vars[v++] = 0;                  /* error */
     vars[v++] = 0; vars[v++] = 0;                  /* other len */
 
+    unsigned char digest_input[sizeof(signed_copy) + sizeof(vars)];
+    memcpy(digest_input, signed_copy, tsig_at);
+    memcpy(digest_input + tsig_at, vars, v);
+
     unsigned char expected[EVP_MAX_MD_SIZE];
     unsigned int expected_len = 0;
-    HMAC_CTX *ctx = HMAC_CTX_new();
-    if (!ctx) return false;
-    bool ok = HMAC_Init_ex(ctx, KEY_SECRET, (int)KEY_SECRET_LEN,
-                           EVP_sha256(), NULL) == 1 &&
-              HMAC_Update(ctx, signed_copy, tsig_at) == 1 &&
-              HMAC_Update(ctx, vars, v) == 1 &&
-              HMAC_Final(ctx, expected, &expected_len) == 1;
-    HMAC_CTX_free(ctx);
-    if (!ok) return false;
+    if (!HMAC(EVP_sha256(), KEY_SECRET, (int)KEY_SECRET_LEN, digest_input,
+              tsig_at + v, expected, &expected_len))
+        return false;
     return expected_len == mac_len && memcmp(expected, mac, mac_len) == 0;
 }
 

--- a/test/test_multi_account.c
+++ b/test/test_multi_account.c
@@ -23,6 +23,7 @@
 
 #include <cJSON.h>
 #include <ftw.h>
+#include <openssl/evp.h>
 #include <sqlite3.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -186,6 +187,27 @@ static int count_events_mentioning(const char *seq_path, const char *did) {
         sqlite3_stmt *stmt = NULL;
         if (sqlite3_prepare_v2(db,
                 "SELECT COUNT(*) FROM events WHERE instr(frame, ?) > 0;",
+                -1, &stmt, NULL) == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, did, -1, SQLITE_STATIC);
+            if (sqlite3_step(stmt) == SQLITE_ROW)
+                found = sqlite3_column_int(stmt, 0);
+        }
+        sqlite3_finalize(stmt);
+    }
+    sqlite3_close(db);
+    return found;
+}
+
+/* #account frames naming `did` and carrying the `deleted` status. */
+static int count_deleted_events_for(const char *seq_path, const char *did) {
+    sqlite3 *db = NULL;
+    int found = 0;
+    if (sqlite3_open(seq_path, &db) == SQLITE_OK) {
+        sqlite3_stmt *stmt = NULL;
+        if (sqlite3_prepare_v2(db,
+                "SELECT COUNT(*) FROM events "
+                "WHERE instr(frame, '#account') > 0 AND instr(frame, ?) > 0 "
+                "AND instr(frame, 'deleted') > 0;",
                 -1, &stmt, NULL) == SQLITE_OK) {
             sqlite3_bind_text(stmt, 1, did, -1, SQLITE_STATIC);
             if (sqlite3_step(stmt) == SQLITE_ROW)
@@ -828,6 +850,63 @@ int main(void) {
         CHECK(body_contains(&response, "carol.example.com"));
         CHECK(body_contains(&response, "did:plc:carol"));
         wf_response_free(&response);
+    }
+
+    /*
+     * Deleting an account takes its history off the firehose too.
+     *
+     * The data directory was already removed, but the commits stayed in the
+     * host log with the record contents inside them, so a consumer
+     * backfilling from an old cursor was still handed the repository of
+     * somebody who had asked to be gone — a deletion that removes the copy
+     * nobody reads and keeps the copy the network does.
+     *
+     * Exactly one event must survive: the `deleted` #account announcement. A
+     * consumer that never sees it cannot tell a deleted account from a host
+     * that simply went quiet.
+     */
+    {
+        char *token_dave = create_account(client, "dave.example.com",
+                                          "did:plc:dave", "davesecret");
+        CHECK(token_dave != NULL);
+        if (token_dave) {
+            wf_xrpc_client_set_auth(client, token_dave);
+            CHECK(create_record(client, "did:plc:dave", "d1", "one") == 200);
+            CHECK(create_record(client, "did:plc:dave", "d2", "two") == 200);
+            wf_xrpc_client_set_auth(client, NULL);
+            /* Creation, identity and two commits at least. */
+            CHECK(count_events_mentioning(shared_seq, "did:plc:dave") > 2);
+
+            int64_t others_before = count_all_events(shared_seq) -
+                count_events_mentioning(shared_seq, "did:plc:dave");
+            wf_response response = {0};
+            char url[256];
+            snprintf(url, sizeof(url),
+                     "%s/xrpc/com.atproto.admin.deleteAccount", base);
+            char cred[64];
+            int n = snprintf(cred, sizeof(cred), "admin:%s", "secret-admin");
+            char b64[128];
+            int len = EVP_EncodeBlock((unsigned char *)b64,
+                                      (const unsigned char *)cred, n);
+            b64[len] = '\0';
+            char auth[160];
+            snprintf(auth, sizeof(auth), "Basic %s", b64);
+            wf_http_header hdr = {"Authorization", auth};
+            CHECK(wf_http_post(client, url, "application/json",
+                               "{\"did\":\"did:plc:dave\"}", &hdr, 1,
+                               &response) == WF_OK);
+            CHECK(response.status == 200);
+            wf_response_free(&response);
+
+            CHECK(count_events_mentioning(shared_seq, "did:plc:dave") == 1);
+            /* The one left is the deletion, and no other account's events
+             * were caught by the sweep. */
+            CHECK(count_deleted_events_for(shared_seq, "did:plc:dave") == 1);
+            CHECK(count_all_events(shared_seq) -
+                  count_events_mentioning(shared_seq, "did:plc:dave") ==
+                  others_before);
+            free(token_dave);
+        }
     }
 
     free(token_bob);

--- a/test/test_takedown.c
+++ b/test/test_takedown.c
@@ -60,6 +60,16 @@ static cJSON *json_response(wf_response *response) {
                                  response->body_len);
 }
 
+/* Case-sensitive substring search over a length-delimited body. */
+static bool body_has(const wf_response *response, const char *needle) {
+    if (!response || !response->body || !needle) return false;
+    size_t nlen = strlen(needle);
+    if (response->body_len < nlen) return false;
+    for (size_t i = 0; i + nlen <= response->body_len; i++)
+        if (memcmp(response->body + i, needle, nlen) == 0) return true;
+    return false;
+}
+
 /* The `error` name from an XRPC error body, or "" when there is none.
  * Copied into `out` because the parsed tree is freed here. */
 static void error_name(wf_response *response, char *out, size_t out_len) {
@@ -540,6 +550,44 @@ int main(void) {
         CHECK(cJSON_IsString(status) &&
               strcmp(status->valuestring, "takendown") == 0);
         cJSON_Delete(json);
+        wf_response_free(&response);
+    }
+
+    /*
+     * /metrics is admin-gated and reports what actually happened.
+     *
+     * Open, it would publish a private host's account count and write rate to
+     * anyone who asked; Prometheus has had basic_auth in its scrape config for
+     * as long as it has existed. The takedown counter is checked here because
+     * this test is the only one that applies any.
+     */
+    {
+        char url[256];
+        snprintf(url, sizeof(url), "%s/metrics", base);
+        CHECK(wf_http_get(client, url, &response) == WF_ERR_HTTP);
+        CHECK(response.status == 401);
+        wf_response_free(&response);
+
+        char cred[64];
+        int n = snprintf(cred, sizeof(cred), "admin:%s", "secret-admin");
+        char b64[128];
+        int len = EVP_EncodeBlock((unsigned char *)b64,
+                                  (const unsigned char *)cred, n);
+        b64[len] = '\0';
+        char auth[160];
+        snprintf(auth, sizeof(auth), "Basic %s", b64);
+        wf_http_header hdr = {"Authorization", auth};
+        CHECK(wf_http_get_with_headers(client, url, &hdr, 1, &response)
+              == WF_OK);
+        CHECK(response.status == 200);
+        /* Prometheus rejects a counter with no TYPE line, so the exposition
+         * has to carry them and not just the samples. */
+        CHECK(body_has(&response, "# TYPE metalbear_takedowns_applied_total counter"));
+        CHECK(body_has(&response, "metalbear_accounts{status=\"takendown\"} 1"));
+        CHECK(body_has(&response, "metalbear_build_info{version="));
+        /* Four takedowns were applied above: a record, a blob, and the
+         * account twice. Lifting one is not an application. */
+        CHECK(body_has(&response, "metalbear_takedowns_applied_total 4"));
         wf_response_free(&response);
     }
 

--- a/test/test_takedown.c
+++ b/test/test_takedown.c
@@ -30,6 +30,7 @@
 
 #include "metalbear/server.h"
 #include "wolfram/xrpc.h"
+#include "wolfram/xrpc_server.h"
 
 #include <cJSON.h>
 #include <ftw.h>
@@ -588,14 +589,20 @@ int main(void) {
         /* Four takedowns were applied above: a record, a blob, and the
          * account twice. Lifting one is not an application. */
         CHECK(body_has(&response, "metalbear_takedowns_applied_total 4"));
+#ifdef WF_XRPC_HAS_REQUEST_OBSERVER
         /*
          * Per-route series, including a plain HTTP route. Those have no NSID
          * and never reach the auth callback, so counting there — which is
          * where the totals used to come from — missed them entirely.
+         *
+         * Guarded like the code that produces them: the observer is an
+         * optional Wolfram feature, and asserting on it unconditionally
+         * makes an optional dependency a required one.
          */
         CHECK(body_has(&response, "metalbear_route_requests_total{route=\"com.atproto.sync.getRepo\"}"));
         CHECK(body_has(&response, "metalbear_route_errors_total{route=\"com.atproto.sync.getRepo\"}"));
         CHECK(body_has(&response, "metalbear_route_requests_total{route=\"/metrics\"}"));
+#endif
         wf_response_free(&response);
     }
 

--- a/test/test_takedown.c
+++ b/test/test_takedown.c
@@ -588,6 +588,14 @@ int main(void) {
         /* Four takedowns were applied above: a record, a blob, and the
          * account twice. Lifting one is not an application. */
         CHECK(body_has(&response, "metalbear_takedowns_applied_total 4"));
+        /*
+         * Per-route series, including a plain HTTP route. Those have no NSID
+         * and never reach the auth callback, so counting there — which is
+         * where the totals used to come from — missed them entirely.
+         */
+        CHECK(body_has(&response, "metalbear_route_requests_total{route=\"com.atproto.sync.getRepo\"}"));
+        CHECK(body_has(&response, "metalbear_route_errors_total{route=\"com.atproto.sync.getRepo\"}"));
+        CHECK(body_has(&response, "metalbear_route_requests_total{route=\"/metrics\"}"));
         wf_response_free(&response);
     }
 


### PR DESCRIPTION
Stacked on #11 — **base is `feat/takedown-model`**, so review that one first
and this diff stays to its own changes.

Together these close the README's **Status** list. One item requires
ewanc26/wolfram#10, which adds the request hook this needs; MetalBear builds
with or without it.

## A deleted account stayed on the firehose

`deleteAccount` removed the data directory and left every commit the account
had made in the host log, record contents and all. Any consumer backfilling
from an old cursor was still handed the repository of somebody who had asked to
be gone — a deletion that removes the copy nobody reads and keeps the copy the
network does.

The log stored a frame and a timestamp, so finding an account's events meant
decoding every frame. Its DID is now recorded and indexed alongside, and the
sweep keeps exactly one event: the `deleted` `#account` announcement, because a
consumer that never sees it cannot tell a deleted account from a host that went
quiet.

The column is *added* to an existing log rather than assumed — a running host's
sequencer file is the one thing it cannot be asked to discard, since every
consumer that ever subscribed holds its sequence numbers. Older rows are matched
on the frame's bytes instead of backfilled, which would mean decoding months of
commits at startup.

No `pruned_through` mark is written: that records where the *start* of the log
was trimmed, and this removes rows from the middle, where a reader asking for
the next event after a cursor never sees the gap.

## Handles only resolved automatically on Cloudflare

Everywhere else the operator wrote one TXT record per account by hand, or
handles never resolved — and nothing surfaces that until every one shows as
`handle.invalid`.

Four providers now sit behind one interface. **DigitalOcean** and **deSEC** are
the other two big hosts; **rfc2136** is the one that is not a vendor at all. It
speaks the dynamic-update protocol the nameservers themselves implement, signed
with TSIG over TCP, so one implementation covers BIND, Knot, PowerDNS, NSD and
anything else standards-compliant — including a nameserver the operator runs.
That is the difference between "your provider is supported" and "your provider
is supported if we wrote code for it".

What the interface has to absorb: DigitalOcean answers a delete with a bodiless
204 that Cloudflare's parse-or-fail path reads as an error; deSEC has no
individual records at all (one RRset replaced wholesale, quoted TXT, 404 for
absence, `Token` not `Bearer`, hour minimum TTL); rfc2136 is not HTTP.

## Nothing reported on a running host

`GET /metrics` in Prometheus format, behind the admin credential. Counters cover
requests and failures, accounts, sessions, commits, blobs, takedowns, firehose
subscribes and disconnects, and DNS and `requestCrawl` failures; gauges report
accounts by status, uptime, and the firehose sequence — the one worth alerting
on, since a PDS whose sequence has stalled is indistinguishable from outside
from a PDS that is down.

Totals originally came from a wrapper around the auth callback, which runs
before the status is known, never runs for a plain HTTP route, and never runs
for a request the rate limiter refused. Consuming Wolfram's new request observer
instead gives every request with its status, plus a bounded per-route table —
bounded because an NSID arrives from the network and an unbounded label set is
how a metrics endpoint becomes the thing that exhausts a host's memory. Overflow
is counted under `other` so the per-route numbers still sum to the total, and
label values are escaped because one quote in a route name produces an
exposition Prometheus rejects wholesale.

`METALBEAR_LOG_FORMAT=json` emits one object per line. The daemon's own startup
and shutdown messages went through bare `fprintf` — tolerable for one format,
not for two, since a plain line inside a JSON stream is one no collector accepts
and it is invariably the line saying why the server would not start.

Timestamps are now UTC. They were formatted from `localtime` and stamped `Z`,
which reads as a correct time in the wrong zone — an error that only surfaces
when two hosts' logs are lined up during an incident.

## Verification

- 14/14 `ctest` from a clean build tree; no new compiler warnings
- **the TSIG signature is verified independently**: the stand-in nameserver
  recomputes the MAC from the received bytes rather than calling the signing
  code, because a signature wrong in a way both sides share is exactly the
  defect that fails against every real server while the suite stays green.
  Confirmed by breaking the signer three ways — ARCOUNT raised before the digest
  instead of after, the wrong key name in the variables, a fudge mismatch — and
  checking each was caught
- the HTTP DNS provider tests were mutation-checked the same way
- `/metrics` exercised against the real daemon: 401 unauthenticated, and every
  counter, gauge and per-route series moved as accounts, records, blobs and
  logins were exercised — including the landing page, which the old auth-callback
  counting could not see
- JSON logging confirmed on a running daemon, including the daemon's own lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lahd4tPa1cWFhQB4YXPvwH