### PR TITLE
Correct repo write error reporting, and make the per-route metric table track the busiest routes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ if(METALBEAR_BUILD_TESTS)
     add_test(NAME metalbear_repo_store_resolver
         COMMAND test_metalbear_repo_store_resolver)
 
+    add_executable(test_metalbear_metrics test/test_metrics.c)
+    target_link_libraries(test_metalbear_metrics PRIVATE metalbear_core)
+    add_test(NAME metalbear_metrics COMMAND test_metalbear_metrics)
+
     add_executable(test_metalbear_blob_store test/test_blob_store.c)
     target_link_libraries(test_metalbear_blob_store PRIVATE metalbear_core)
     target_include_directories(test_metalbear_blob_store PRIVATE

--- a/README.md
+++ b/README.md
@@ -510,11 +510,17 @@ MetalBear federates. A running instance is consumed by Bluesky's relays and by
 several third-party ones, its commits verify against the key published in the
 PLC directory, and its posts, profile and media appear on the Bluesky AppView.
 
-Still missing or unproven for production use:
+Nothing on the list of known gaps is outstanding. The last of them was the
+per-route metric table, which used to stop naming routes once it held 128 of
+them; it now tracks the busiest routes instead, folding the least-used one into
+`other` when it is full, and the limit is configurable up to 1024 via
+`limits.metrics_max_routes`. The table stays bounded on purpose: route names
+reach it from the network, and an unbounded label set is a way to exhaust the
+host's memory.
 
-- the per-route metric table is bounded at 128 routes, after which traffic is
-  counted under `other` rather than by name — enough for the protocol surface,
-  but a host proxying a large AppView surface will spill
+What remains is the work no checklist covers — running against more clients,
+more relays, and more traffic than it has seen. Reports of anything that
+misbehaves are the most useful thing you can send.
 
 ## Frontend
 
@@ -536,8 +542,8 @@ current documentation, but it explains why accounts are arranged as they are.
 ## Sponsor
 
 MetalBear is developed in spare time and given away under the AGPL. If it saved
-you the trouble of running a PDS the hard way, or you would like the missing
-pieces under **Status** to arrive sooner, you can fund the work:
+you the trouble of running a PDS the hard way, or you would like the work under
+**Status** to keep moving, you can fund it:
 
 **→ [github.com/sponsors/ewanc26](https://github.com/sponsors/ewanc26)**
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -68,6 +68,13 @@ rate_limit_window_seconds = 60
 # disk-exhaustion lever; the reference uses 5 MB.
 blob_upload_bytes = 5242880
 
+# How many routes /metrics reports by name. The table is a fixed array, because
+# route names arrive from the network and an unbounded label set exhausts the
+# host's memory; this only chooses how much of that fixed budget to spend, up
+# to a hard ceiling of 1024. Beyond the limit the least-used route is folded
+# into `other`, so the busiest routes stay named and the totals stay exact.
+metrics_max_routes = 128
+
 [firehose]
 # Relays told about new data via requestCrawl on write. Without any, a quiet
 # host is never crawled and never federates.

--- a/include/metalbear/metrics.h
+++ b/include/metalbear/metrics.h
@@ -17,6 +17,7 @@
  * than it costs.
  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -66,12 +67,37 @@ uint64_t metalbear_metrics_get(metalbear_metric metric);
  * enumerated up front, because the set is not fixed — the AppView proxy
  * forwards NSIDs this server has never heard of.
  *
- * The table is bounded. An unbounded label set is how a metrics endpoint
- * becomes the thing that exhausts a host's memory, and an NSID arrives from
- * the network. Requests beyond the bound are still counted, under the name
- * `other`, so the totals stay honest.
+ * The table is bounded, and the bound is not negotiable: an unbounded label
+ * set is how a metrics endpoint becomes the thing that exhausts a host's
+ * memory, and an NSID arrives from the network. The storage is a fixed array
+ * of METALBEAR_METRICS_ROUTE_CEILING rows, sized at compile time, so no
+ * configuration and no traffic pattern can make the table grow.
+ *
+ * Within that ceiling the capacity is what an operator chooses, defaulting to
+ * METALBEAR_METRICS_MAX_ROUTES, and a full table evicts its *least-used* route
+ * rather than freezing. Freezing was the real defect: the first 128 names seen
+ * kept their rows forever, so a route that became hot after startup — which is
+ * to say, the one an operator went looking for — was invisible for the life of
+ * the process, while a burst of junk NSIDs seen during boot held rows on
+ * nothing. Evicting the coldest row is also self-defending: a flood of
+ * one-request names evicts the previous one-request name, never the busy route
+ * beside it.
+ *
+ * Evicted counts, and requests that arrive while the table is at capacity,
+ * are folded into the name `other`, so per-route totals still sum to the
+ * overall request count.
  */
 #define METALBEAR_METRICS_MAX_ROUTES 128
+#define METALBEAR_METRICS_ROUTE_CEILING 1024
+
+/*
+ * Set the number of routes tracked by name. Clamped to
+ * [1, METALBEAR_METRICS_ROUTE_CEILING]; zero restores the default. Lowering it
+ * below the number of rows in use folds the coldest of them into `other`
+ * rather than losing their counts. Called once at startup.
+ */
+void metalbear_metrics_set_max_routes(size_t max_routes);
+size_t metalbear_metrics_max_routes(void);
 
 /* Record one finished request. `nsid` may be NULL for a plain HTTP route, in
  * which case `path` names it. */

--- a/include/metalbear/server.h
+++ b/include/metalbear/server.h
@@ -80,6 +80,15 @@ typedef struct metalbear_config {
     int64_t crawl_notify_seconds;
     int64_t firehose_ping_seconds;
     /*
+     * How many routes `GET /metrics` reports by name before the least-used one
+     * is folded into `other`. Zero uses METALBEAR_METRICS_MAX_ROUTES, and
+     * anything above METALBEAR_METRICS_ROUTE_CEILING is clamped to it — the
+     * table is a fixed array, and route names arrive from the network, so this
+     * chooses how much of a bounded budget to spend, never whether to have one.
+     * A host proxying a wide AppView surface will want it higher.
+     */
+    int64_t metrics_max_routes;
+    /*
      * Who runs this instance, and what to say about it.
      *
      * `contact_email` and the two policy links are the fields

--- a/metalbear.env.example
+++ b/metalbear.env.example
@@ -35,6 +35,11 @@ METALBEAR_INVITE_REQUIRED=false
 # 0 => unlimited (only sensible behind your own quota).
 METALBEAR_BLOB_UPLOAD_LIMIT=5242880
 
+# --- per-route metrics table ---
+# Routes reported by name at /metrics; the least-used one is folded into
+# `other` beyond this. Fixed array underneath, hard ceiling 1024.
+# METALBEAR_METRICS_MAX_ROUTES=128
+
 # --- optional email ---
 # METALBEAR_SMTP_HOST=
 # METALBEAR_SMTP_PORT=587

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -221,6 +221,7 @@ wf_status metalbear_config_file_load(const char *path,
         INT ("limits.rate_limit",                rate_limit)
         INT ("limits.rate_limit_window_seconds", rate_limit_window)
         INT ("limits.blob_upload_bytes",         blob_upload_limit)
+        INT ("limits.metrics_max_routes",        metrics_max_routes)
 
         INT ("firehose.retention_max_age_seconds", retention_max_age_seconds)
         INT ("firehose.retention_min_events",      retention_min_events)

--- a/src/main.c
+++ b/src/main.c
@@ -253,6 +253,7 @@ int main(int argc, char **argv) {
     ENV_I64("METALBEAR_RETENTION_MAX_AGE",       retention_max_age_seconds);
     ENV_I64("METALBEAR_RETENTION_MIN_EVENTS",    retention_min_events);
     ENV_I64("METALBEAR_DNS_TTL",                 dns_record_ttl);
+    ENV_I64("METALBEAR_METRICS_MAX_ROUTES",      metrics_max_routes);
     #undef ENV_STR
     #undef ENV_I64
 

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -14,6 +14,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static _Atomic uint64_t counters[METALBEAR_METRIC_COUNT];
@@ -99,13 +100,57 @@ typedef struct route_row {
     uint64_t errors;
 } route_row;
 
-static route_row routes[METALBEAR_METRICS_MAX_ROUTES];
+/*
+ * Storage is a fixed array sized at compile time. The configurable capacity
+ * only ever selects a prefix of it, so however the knob is set — or however
+ * many distinct NSIDs the network invents — this is all the memory per-route
+ * accounting can ever occupy.
+ */
+static route_row routes[METALBEAR_METRICS_ROUTE_CEILING];
 static size_t route_count;
+static size_t route_capacity = METALBEAR_METRICS_MAX_ROUTES;
 static pthread_mutex_t routes_lock = PTHREAD_MUTEX_INITIALIZER;
-/* Requests that arrived after the table filled up. Counted rather than
+/* Counts that are no longer attributed to a name: requests that arrived while
+ * the table was at capacity, and rows evicted to make room. Kept rather than
  * dropped, so the per-route numbers always sum to the total. */
 static uint64_t overflow_requests;
 static uint64_t overflow_errors;
+
+/* Index of the row with the fewest requests. Ties go to the earlier row, which
+ * makes eviction deterministic and therefore testable. Caller holds the lock;
+ * only called with a non-empty table. */
+static size_t coldest_row(void) {
+    size_t cold = 0;
+    for (size_t i = 1; i < route_count; i++)
+        if (routes[i].requests < routes[cold].requests) cold = i;
+    return cold;
+}
+
+/* Fold a row's counts into `other` and remove it, keeping the table dense.
+ * Caller holds the lock. */
+static void evict_row(size_t idx) {
+    overflow_requests += routes[idx].requests;
+    overflow_errors += routes[idx].errors;
+    route_count--;
+    if (idx != route_count) routes[idx] = routes[route_count];
+}
+
+void metalbear_metrics_set_max_routes(size_t max_routes) {
+    if (max_routes == 0) max_routes = METALBEAR_METRICS_MAX_ROUTES;
+    if (max_routes > METALBEAR_METRICS_ROUTE_CEILING)
+        max_routes = METALBEAR_METRICS_ROUTE_CEILING;
+    pthread_mutex_lock(&routes_lock);
+    route_capacity = max_routes;
+    while (route_count > route_capacity) evict_row(coldest_row());
+    pthread_mutex_unlock(&routes_lock);
+}
+
+size_t metalbear_metrics_max_routes(void) {
+    pthread_mutex_lock(&routes_lock);
+    size_t n = route_capacity;
+    pthread_mutex_unlock(&routes_lock);
+    return n;
+}
 
 void metalbear_metrics_record_request(const char *nsid, const char *path,
                                       unsigned int status) {
@@ -122,12 +167,24 @@ void metalbear_metrics_record_request(const char *nsid, const char *path,
             return;
         }
     }
-    if (route_count < METALBEAR_METRICS_MAX_ROUTES) {
+    /*
+     * A new name and no room. Give the row to the least-used route instead of
+     * refusing every name after the first `capacity` of them: the table then
+     * keeps tracking whatever is actually busy, and an attacker cannot displace
+     * a hot route with junk, because the coldest row is by definition one of
+     * the junk names already there. The displaced counts move to `other`, so
+     * nothing is lost from the totals — only from attribution.
+     */
+    if (route_count >= route_capacity && route_count > 0)
+        evict_row(coldest_row());
+    if (route_count < route_capacity) {
         route_row *row = &routes[route_count++];
         snprintf(row->name, sizeof(row->name), "%s", name);
         row->requests = 1;
         row->errors = is_error ? 1 : 0;
     } else {
+        /* capacity 0 is impossible (clamped to >= 1), but keep the totals
+         * honest rather than assume it. */
         overflow_requests++;
         if (is_error) overflow_errors++;
     }
@@ -141,19 +198,35 @@ void metalbear_metrics_visit_routes(metalbear_metrics_route_visitor visit,
      * Copied out under the lock and visited outside it. The visitor formats
      * into a growing buffer, and holding a lock the request path needs across
      * an allocation is how a scrape starts blocking writes.
+     *
+     * The copy is on the heap: the table can be configured up to the ceiling,
+     * and a snapshot of that size is more than a worker thread's stack should
+     * be asked to hold. If the allocation fails the scrape visits under the
+     * lock instead — a slower scrape beats a silent one.
      */
-    route_row snapshot[METALBEAR_METRICS_MAX_ROUTES];
     size_t count;
     uint64_t spilled_requests, spilled_errors;
     pthread_mutex_lock(&routes_lock);
     count = route_count;
-    memcpy(snapshot, routes, count * sizeof(route_row));
+    route_row *snapshot = count ? malloc(count * sizeof(route_row)) : NULL;
+    if (count && !snapshot) {
+        for (size_t i = 0; i < count; i++)
+            visit(ctx, routes[i].name, routes[i].requests, routes[i].errors);
+        spilled_requests = overflow_requests;
+        spilled_errors = overflow_errors;
+        pthread_mutex_unlock(&routes_lock);
+        if (spilled_requests)
+            visit(ctx, "other", spilled_requests, spilled_errors);
+        return;
+    }
+    if (count) memcpy(snapshot, routes, count * sizeof(route_row));
     spilled_requests = overflow_requests;
     spilled_errors = overflow_errors;
     pthread_mutex_unlock(&routes_lock);
 
     for (size_t i = 0; i < count; i++)
         visit(ctx, snapshot[i].name, snapshot[i].requests, snapshot[i].errors);
+    free(snapshot);
     if (spilled_requests) visit(ctx, "other", spilled_requests, spilled_errors);
 }
 

--- a/src/repo_store.c
+++ b/src/repo_store.c
@@ -1043,19 +1043,30 @@ wf_status metalbear_repo_store_create_record(metalbear_repo_store *s, const char
     *out_uri = NULL;
     *out_cid = NULL;
 
-    /* (c) record-key validation (atproto charset/length rules). */
+    /* (c) record-key validation (atproto charset/length rules).
+     *
+     * The generic status is correct: `com.atproto.repo.createRecord` declares
+     * exactly one error, `InvalidSwap`, and the reference converts its internal
+     * InvalidRecordKeyError into a plain InvalidRequestError carrying the
+     * message. There is no `InvalidRecordKey` name in the lexicons, so a client
+     * could not branch on one. The detail belongs in the message, which
+     * `check_rkey` in the route handler supplies as "Invalid record key:
+     * <rkey>" before the request ever reaches here. */
     char rkey_buf[16];
     const char *rkey = rkey_or_null;
     if (!rkey || !*rkey) {
         if (wf_tid_now(rkey_buf) != WF_OK) return WF_ERR_INVALID_ARG;
         rkey = rkey_buf;
     } else if (!wf_syntax_record_key_is_valid(rkey)) {
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns InvalidRecordKey */
+        return WF_ERR_INVALID_ARG;
     }
 
-    /* (b) $type, when present, must equal the target collection. */
+    /* (b) $type, when present, must equal the target collection. Same story:
+     * the reference raises InvalidRecordError and reports it as InvalidRequest
+     * with "Invalid $type: expected <x>, got <y>", which `check_record`
+     * produces for HTTP callers. `InvalidRecord` is not a lexicon name. */
     if (!record_type_matches(record_json, collection))
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns InvalidRecord */
+        return WF_ERR_INVALID_ARG;
 
     /* (a) CAS: swapCommit must match the current repo head (if supplied). */
     char *head = head_cid_string(s);
@@ -1104,13 +1115,16 @@ wf_status metalbear_repo_store_put_record(metalbear_repo_store *s, const char *c
     *out_uri = NULL;
     *out_cid = NULL;
 
-    /* (c) record-key validation (atproto charset/length rules). */
+    /* (c) record-key validation. `putRecord` declares only `InvalidSwap`, so
+     * the generic status is right; `check_rkey` names the offending key in the
+     * message. See create_record above. */
     if (!wf_syntax_record_key_is_valid(rkey))
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns InvalidRecordKey */
+        return WF_ERR_INVALID_ARG;
 
-    /* (b) $type, when present, must equal the target collection. */
+    /* (b) $type, when present, must equal the target collection; reported as
+     * "Invalid $type: expected <x>, got <y>" by `check_record`. */
     if (!record_type_matches(record_json, collection))
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns InvalidRecord */
+        return WF_ERR_INVALID_ARG;
 
     /* Detect whether the record already exists. */
     unsigned char *existing = NULL;
@@ -1181,9 +1195,11 @@ wf_status metalbear_repo_store_delete_record(metalbear_repo_store *s, const char
     if (!s || !collection || !*collection || !rkey || !*rkey)
         return WF_ERR_INVALID_ARG;
 
-    /* (c) record-key validation (atproto charset/length rules). */
+    /* (c) record-key validation. `deleteRecord` declares only `InvalidSwap`,
+     * so the generic status is right; `check_rkey` names the offending key in
+     * the message. See create_record above. */
     if (!wf_syntax_record_key_is_valid(rkey))
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns InvalidRecordKey */
+        return WF_ERR_INVALID_ARG;
     if (s->head.len == 0) return WF_ERR_NOT_FOUND;
 
     unsigned char *existing = NULL;
@@ -1278,10 +1294,14 @@ wf_status metalbear_repo_store_apply_writes(metalbear_repo_store *s, const char 
     free(head);
     if (st != WF_OK) { cJSON_Delete(root); return st; }
 
-    /* (g) cap batch size at 200 writes (mirrors atproto's limit). */
+    /* (g) cap batch size at 200 writes (mirrors atproto's limit). The
+     * reference raises a plain InvalidRequestError('Too many writes. Max:
+     * 200') — `applyWrites` declares only `InvalidSwap`, and there is no
+     * `TooManyWrites` name anywhere in the lexicons. The route handler emits
+     * that exact message before calling in here. */
     if (cJSON_GetArraySize(root) > 200) {
         cJSON_Delete(root);
-        return WF_ERR_INVALID_ARG; /* TODO: atproto returns TooManyWrites */
+        return WF_ERR_INVALID_ARG;
     }
 
     cJSON *results = cJSON_CreateArray();
@@ -1340,8 +1360,11 @@ wf_status metalbear_repo_store_apply_writes(metalbear_repo_store *s, const char 
             if (wf_tid_now(tid) != WF_OK) { st = WF_ERR_INTERNAL; goto done; }
             rkeys[staged] = strdup(tid);
         } else {
+            /* Generic status, precise message: the handler runs `check_rkey`
+             * over every write first and answers "Invalid record key: <rkey>".
+             * `InvalidRecordKey` is not a name applyWrites declares. */
             if (!wf_syntax_record_key_is_valid(rkey)) {
-                st = WF_ERR_INVALID_ARG; /* TODO: atproto InvalidRecordKey */
+                st = WF_ERR_INVALID_ARG;
                 goto done;
             }
             rkeys[staged] = strdup(rkey);
@@ -1357,9 +1380,12 @@ wf_status metalbear_repo_store_apply_writes(metalbear_repo_store *s, const char 
             if (!val) { st = WF_ERR_INVALID_ARG; goto done; }
             char *rec_json = cJSON_PrintUnformatted(val);
             if (!rec_json) { st = WF_ERR_ALLOC; goto done; }
+            /* Likewise: `check_record` has already answered "Invalid $type:
+             * expected <x>, got <y>" for HTTP callers, and `InvalidRecord` is
+             * not a lexicon-defined name. */
             if (!record_type_matches(rec_json, collections[staged])) {
                 free(rec_json);
-                st = WF_ERR_INVALID_ARG; /* TODO: atproto InvalidRecord */
+                st = WF_ERR_INVALID_ARG;
                 goto done;
             }
             values[staged] = rec_json;
@@ -1675,7 +1701,7 @@ static bool query_param_bool(const cJSON *params, const char *name,
  * Run a write's record through the lexicon corpus and report the outcome the
  * way the reference PDS does.
  *
- * Returns 0 and writes an `InvalidRecord` response when the record has a
+ * Returns 0 and writes an `InvalidRequest` response when the record has a
  * schema and violates it, or when the caller passed validate:true for a
  * collection with no schema. Returns 1 to continue, with *out_status set to
  * the value that belongs in the response's validationStatus and *out_report
@@ -1696,9 +1722,12 @@ static int check_record(const metalbear_pds_repo_bundle *b, const cJSON *body,
 
     *out_status = METALBEAR_VALIDATION_UNKNOWN;
     *out_report = !explicit_off;
-    if (explicit_off) return 1;
 
-    /* The $type, when present, must name the collection being written to. */
+    /* The $type, when present, must name the collection being written to.
+     * This is checked BEFORE honouring validate:false, because the reference
+     * does it in prepareWrite — outside validateRecord, which is the only part
+     * validate:false skips. Gating it on validation left the store's own
+     * $type guard to reject the write with nothing but a generic message. */
     cJSON *parsed = cJSON_Parse(record_json);
     cJSON *type = parsed
         ? cJSON_GetObjectItemCaseSensitive(parsed, "$type") : NULL;
@@ -1712,6 +1741,8 @@ static int check_record(const metalbear_pds_repo_bundle *b, const cJSON *body,
         return 0;
     }
     cJSON_Delete(parsed);
+
+    if (explicit_off) return 1;
 
     /* The reference reports every record problem as a plain InvalidRequest
      * carrying a descriptive message — its InvalidRecordError is an internal
@@ -1925,6 +1956,10 @@ static wf_status h_delete_record(void *ctx, const wf_xrpc_request *req,
                                     "collection and rkey required");
         return WF_OK;
     }
+    /* A malformed rkey is rejected here rather than deep in the store, so the
+     * client is told which key was rejected instead of "record could not be
+     * deleted". */
+    if (!check_rkey(rkey, resp)) return WF_OK;
     const char *swap_str = (swap && cJSON_IsString(swap)) ? swap->valuestring
                                                          : NULL;
     const char *swaprec_str = (swapRec && cJSON_IsString(swapRec))

--- a/src/server.c
+++ b/src/server.c
@@ -7022,6 +7022,8 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
         crawler_notify_seconds = (time_t)config->crawl_notify_seconds;
     if (config->firehose_ping_seconds > 0)
         metalbear_sequencer_set_ping_seconds(config->firehose_ping_seconds);
+    if (config->metrics_max_routes > 0)
+        metalbear_metrics_set_max_routes((size_t)config->metrics_max_routes);
 
     /* Per-client request budget, configurable; 100 per 60s by default. */
     {

--- a/test/test_metrics.c
+++ b/test/test_metrics.c
@@ -1,0 +1,277 @@
+/*
+ * test_metrics.c — the per-route metrics table, and what it does when full.
+ *
+ * The bound is a security property: route names arrive from the network (the
+ * AppView proxy forwards NSIDs this server has never heard of), so an
+ * unbounded label set is a memory-exhaustion lever. These tests pin both
+ * halves of the design — the bound holds under a flood of distinct names, and
+ * the table still tracks the busiest routes rather than freezing on whatever
+ * it happened to see first.
+ */
+
+#include "metalbear/metrics.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            failures++;                                                      \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);  \
+        }                                                                    \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/* Collecting the visitor's output                                     */
+/* ------------------------------------------------------------------ */
+
+typedef struct seen_row {
+    char name[128];
+    uint64_t requests;
+    uint64_t errors;
+} seen_row;
+
+typedef struct collected {
+    seen_row rows[METALBEAR_METRICS_ROUTE_CEILING + 8];
+    size_t count;
+    int overflowed;
+} collected;
+
+static void collect(void *ctx, const char *route, uint64_t requests,
+                    uint64_t errors) {
+    collected *c = ctx;
+    if (c->count >= sizeof(c->rows) / sizeof(c->rows[0])) {
+        c->overflowed = 1;
+        return;
+    }
+    seen_row *row = &c->rows[c->count++];
+    snprintf(row->name, sizeof(row->name), "%s", route);
+    row->requests = requests;
+    row->errors = errors;
+}
+
+static void snapshot(collected *out) {
+    memset(out, 0, sizeof(*out));
+    metalbear_metrics_visit_routes(collect, out);
+}
+
+static const seen_row *find(const collected *c, const char *name) {
+    for (size_t i = 0; i < c->count; i++)
+        if (strcmp(c->rows[i].name, name) == 0) return &c->rows[i];
+    return NULL;
+}
+
+static uint64_t total_requests(const collected *c) {
+    uint64_t n = 0;
+    for (size_t i = 0; i < c->count; i++) n += c->rows[i].requests;
+    return n;
+}
+
+static uint64_t total_errors(const collected *c) {
+    uint64_t n = 0;
+    for (size_t i = 0; i < c->count; i++) n += c->rows[i].errors;
+    return n;
+}
+
+static void hit(const char *nsid, unsigned int status, unsigned int times) {
+    for (unsigned int i = 0; i < times; i++)
+        metalbear_metrics_record_request(nsid, NULL, status);
+}
+
+/* ------------------------------------------------------------------ */
+
+/* Ordinary accounting: a route is reported by name, with its error count. */
+static void test_basic(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(8);
+    CHECK(metalbear_metrics_max_routes() == 8);
+
+    hit("com.atproto.repo.createRecord", 200, 3);
+    hit("com.atproto.repo.createRecord", 400, 2);
+    metalbear_metrics_record_request(NULL, "/metrics", 200);
+    /* Neither an NSID nor a path: still counted, never dropped. */
+    metalbear_metrics_record_request(NULL, NULL, 200);
+
+    collected c;
+    snapshot(&c);
+    const seen_row *create = find(&c, "com.atproto.repo.createRecord");
+    CHECK(create && create->requests == 5 && create->errors == 2);
+    const seen_row *metrics = find(&c, "/metrics");
+    CHECK(metrics && metrics->requests == 1 && metrics->errors == 0);
+    CHECK(find(&c, "unknown") != NULL);
+    CHECK(find(&c, "other") == NULL);
+    CHECK(total_requests(&c) == 7);
+}
+
+/*
+ * The bound holds. A flood of distinct names — which is what an attacker
+ * pointing junk NSIDs at the AppView proxy produces — never grows the table
+ * past its capacity, and every request is still counted somewhere.
+ */
+static void test_bound_holds_under_flood(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(16);
+
+    for (int i = 0; i < 5000; i++) {
+        char name[64];
+        snprintf(name, sizeof(name), "junk.example.route%d", i);
+        metalbear_metrics_record_request(name, NULL, i % 7 == 0 ? 500 : 200);
+    }
+
+    collected c;
+    snapshot(&c);
+    CHECK(!c.overflowed);
+    /* At most the capacity, plus the single `other` row. */
+    CHECK(c.count <= 17);
+    /* Not one request lost: named rows plus `other` equal what was recorded. */
+    CHECK(total_requests(&c) == 5000);
+    CHECK(total_errors(&c) == 715); /* every 7th of 0..4999 */
+}
+
+/*
+ * A busy route is not displaced by junk. This is the eviction policy's whole
+ * point: the coldest row is one of the one-request junk names, so a flood
+ * churns through a single slot and leaves the routes an operator cares about
+ * reported by name.
+ */
+static void test_hot_route_survives_flood(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(4);
+
+    hit("app.bsky.feed.getTimeline", 200, 500);
+    hit("com.atproto.sync.getRepo", 200, 100);
+    for (int i = 0; i < 1000; i++) {
+        char name[64];
+        snprintf(name, sizeof(name), "junk.example.route%d", i);
+        metalbear_metrics_record_request(name, NULL, 200);
+    }
+
+    collected c;
+    snapshot(&c);
+    const seen_row *hot = find(&c, "app.bsky.feed.getTimeline");
+    CHECK(hot && hot->requests == 500);
+    const seen_row *warm = find(&c, "com.atproto.sync.getRepo");
+    CHECK(warm && warm->requests == 100);
+    const seen_row *other = find(&c, "other");
+    CHECK(other != NULL);
+    CHECK(total_requests(&c) == 1600);
+}
+
+/*
+ * The defect this replaces: a full table used to freeze, so a route that only
+ * became busy after startup was reported as `other` for the life of the
+ * process. It now takes the least-used row and is named.
+ */
+static void test_late_route_is_admitted(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(3);
+
+    hit("early.one", 200, 10);
+    hit("early.two", 200, 10);
+    hit("early.three", 200, 1);
+
+    /* The table is full, and `early.three` is the coldest row. */
+    hit("late.hot", 200, 50);
+
+    collected c;
+    snapshot(&c);
+    const seen_row *late = find(&c, "late.hot");
+    CHECK(late && late->requests == 50);
+    CHECK(find(&c, "early.three") == NULL);
+    CHECK(find(&c, "early.one") != NULL);
+    CHECK(find(&c, "early.two") != NULL);
+    /* The evicted row's single request moved to `other`, not to nowhere. */
+    const seen_row *other = find(&c, "other");
+    CHECK(other && other->requests == 1);
+    CHECK(total_requests(&c) == 71);
+}
+
+/*
+ * The configured capacity is clamped to the compile-time ceiling. This is the
+ * memory-safety property in one line: the storage is a fixed array, so a
+ * mistyped config cannot make the table larger than the array.
+ */
+static void test_capacity_is_clamped(void) {
+    metalbear_metrics_reset();
+
+    metalbear_metrics_set_max_routes(1000000);
+    CHECK(metalbear_metrics_max_routes() == METALBEAR_METRICS_ROUTE_CEILING);
+
+    /* Zero means "the default", not "track nothing". */
+    metalbear_metrics_set_max_routes(0);
+    CHECK(metalbear_metrics_max_routes() == METALBEAR_METRICS_MAX_ROUTES);
+
+    /* One is honoured, and a second name displaces the first. */
+    metalbear_metrics_set_max_routes(1);
+    CHECK(metalbear_metrics_max_routes() == 1);
+    hit("only.one", 200, 3);
+    hit("only.two", 200, 1);
+    collected c;
+    snapshot(&c);
+    CHECK(c.count == 2); /* one route plus `other` */
+    CHECK(find(&c, "only.two") != NULL);
+    CHECK(total_requests(&c) == 4);
+}
+
+/* Lowering the capacity below what is already tracked folds the coldest rows
+ * into `other` rather than dropping their counts on the floor. */
+static void test_shrinking_capacity_keeps_totals(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(8);
+
+    hit("a.route", 200, 40);
+    hit("b.route", 400, 30);
+    hit("c.route", 200, 20);
+    hit("d.route", 200, 10);
+
+    metalbear_metrics_set_max_routes(2);
+
+    collected c;
+    snapshot(&c);
+    CHECK(c.count == 3); /* two routes plus `other` */
+    CHECK(find(&c, "a.route") != NULL);
+    CHECK(find(&c, "b.route") != NULL);
+    const seen_row *other = find(&c, "other");
+    CHECK(other && other->requests == 30); /* c + d */
+    CHECK(total_requests(&c) == 100);
+    CHECK(total_errors(&c) == 30);
+}
+
+/* reset() clears the rows and the overflow together; a leftover `other` would
+ * make the next test's totals wrong in a way that looks like a real bug. */
+static void test_reset_clears_overflow(void) {
+    metalbear_metrics_reset();
+    metalbear_metrics_set_max_routes(1);
+    hit("first.route", 200, 5);
+    hit("second.route", 200, 5);
+
+    metalbear_metrics_reset();
+    collected c;
+    snapshot(&c);
+    CHECK(c.count == 0);
+}
+
+int main(void) {
+    test_basic();
+    test_bound_holds_under_flood();
+    test_hot_route_survives_flood();
+    test_late_route_is_admitted();
+    test_capacity_is_clamped();
+    test_shrinking_capacity_keeps_totals();
+    test_reset_clears_overflow();
+
+    /* Leave the process-wide table as a fresh server would find it. */
+    metalbear_metrics_set_max_routes(0);
+    metalbear_metrics_reset();
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("test_metrics: OK\n");
+    return 0;
+}

--- a/test/test_repo_store.c
+++ b/test/test_repo_store.c
@@ -942,6 +942,185 @@ static int run_server(void) {
     return failures;
 }
 
+/*
+ * The write endpoints' error names, over HTTP.
+ *
+ * `com.atproto.repo.{create,put,delete}Record` and `applyWrites` each declare
+ * exactly ONE error in the lexicon: `InvalidSwap`. Everything else the
+ * reference PDS reports is a plain `InvalidRequest` whose *message* carries
+ * the detail — its InvalidRecordError / InvalidRecordKeyError are internal
+ * TypeScript classes converted to InvalidRequestError(err.message), and
+ * `InvalidRecordKey`, `InvalidRecord` and `TooManyWrites` appear nowhere in
+ * the lexicon corpus. These assertions pin both halves of that: the generic
+ * name, and the specific message, so nobody "upgrades" the name to an
+ * invented one that no client can match on.
+ */
+static void expect_xrpc_error(const wf_response *res, const char *want_error,
+                              const char *want_message) {
+    cJSON *root = cJSON_ParseWithLength(res->body, res->body_len);
+    cJSON *err = root ? cJSON_GetObjectItemCaseSensitive(root, "error") : NULL;
+    cJSON *msg = root ? cJSON_GetObjectItemCaseSensitive(root, "message") : NULL;
+    int ok = res->status == 400 && cJSON_IsString(err) && cJSON_IsString(msg) &&
+             strcmp(err->valuestring, want_error) == 0 &&
+             strcmp(msg->valuestring, want_message) == 0;
+    if (!ok)
+        fprintf(stderr,
+                "  wanted 400 %s / \"%s\", got %ld %s / \"%s\"\n",
+                want_error, want_message, (long)res->status,
+                cJSON_IsString(err) ? err->valuestring : "(none)",
+                cJSON_IsString(msg) ? msg->valuestring : "(none)");
+    WF_CHECK(ok);
+    cJSON_Delete(root);
+}
+
+static int run_write_error_names(void) {
+    int failures = 0;
+    char path[256];
+    temp_path(path, sizeof(path), "errnames");
+
+    metalbear_repo_store *store = NULL;
+    wf_status s = metalbear_repo_store_open(path, "did:plc:errnames",
+                                            "err.example.com", &store);
+    WF_CHECK(s == WF_OK && store != NULL);
+    if (s != WF_OK || !store) {
+        unlink(path);
+        return failures + 1;
+    }
+
+    wf_xrpc_server *server = wf_xrpc_server_start("127.0.0.1", 0, 1);
+    WF_CHECK(server != NULL);
+    if (!server) {
+        metalbear_repo_store_free(store);
+        unlink(path);
+        return failures + 1;
+    }
+    WF_CHECK(metalbear_xrpc_server_register_pds_repo(server, store, NULL,
+                                                     NULL) == WF_OK);
+    char base[64];
+    snprintf(base, sizeof(base), "http://127.0.0.1:%u",
+             (unsigned)wf_xrpc_server_port(server));
+    wf_xrpc_client *client = wf_xrpc_client_new(base);
+    WF_CHECK(client != NULL);
+
+    wf_response res = {0};
+
+    /* createRecord, malformed record key. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.createRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"rkey\":\"bad key\",\"record\":{\"text\":\"x\"}}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest", "Invalid record key: bad key");
+    wf_response_free(&res);
+
+    /* createRecord, $type disagreeing with the collection. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.createRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"record\":{\"$type\":\"com.example.other\",\"text\":\"x\"}}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest",
+                      "Invalid $type: expected com.example.posts, got "
+                      "com.example.other");
+    wf_response_free(&res);
+
+    /* Same, with validate:false. The reference checks $type in prepareWrite,
+     * outside the part validate:false skips, so the specific message must
+     * still come back rather than a bare "record creation failed". */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.createRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"validate\":false,"
+        "\"record\":{\"$type\":\"com.example.other\",\"text\":\"x\"}}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest",
+                      "Invalid $type: expected com.example.posts, got "
+                      "com.example.other");
+    wf_response_free(&res);
+
+    /* putRecord, malformed record key. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.putRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"rkey\":\"bad/key\",\"record\":{\"text\":\"x\"}}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest", "Invalid record key: bad/key");
+    wf_response_free(&res);
+
+    /* deleteRecord, malformed record key: previously answered "record could
+     * not be deleted", which told the client nothing about what was wrong. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.deleteRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"rkey\":\"bad key\"}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest", "Invalid record key: bad key");
+    wf_response_free(&res);
+
+    /* applyWrites, malformed record key inside one write. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.applyWrites",
+        "{\"repo\":\"did:plc:errnames\",\"writes\":[{"
+        "\"$type\":\"com.atproto.repo.applyWrites#create\","
+        "\"collection\":\"com.example.posts\",\"rkey\":\"bad key\","
+        "\"value\":{\"text\":\"x\"}}]}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest", "Invalid record key: bad key");
+    wf_response_free(&res);
+
+    /* applyWrites, $type disagreeing with the collection. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.applyWrites",
+        "{\"repo\":\"did:plc:errnames\",\"writes\":[{"
+        "\"$type\":\"com.atproto.repo.applyWrites#create\","
+        "\"collection\":\"com.example.posts\","
+        "\"value\":{\"$type\":\"com.example.other\",\"text\":\"x\"}}]}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidRequest",
+                      "Invalid $type: expected com.example.posts, got "
+                      "com.example.other");
+    wf_response_free(&res);
+
+    /* applyWrites, batch over the 200-write cap. */
+    size_t cap = 201;
+    const char *one =
+        "{\"$type\":\"com.atproto.repo.applyWrites#create\","
+        "\"collection\":\"com.example.posts\",\"value\":{\"text\":\"x\"}}";
+    size_t body_cap = 64 + cap * (strlen(one) + 1);
+    char *big = malloc(body_cap);
+    WF_CHECK(big != NULL);
+    if (big) {
+        size_t n = (size_t)snprintf(big, body_cap,
+                                    "{\"repo\":\"did:plc:errnames\",\"writes\":[");
+        for (size_t i = 0; i < cap; i++)
+            n += (size_t)snprintf(big + n, body_cap - n, "%s%s",
+                                  i ? "," : "", one);
+        snprintf(big + n, body_cap - n, "]}");
+        s = wf_xrpc_procedure(client, "com.atproto.repo.applyWrites", big, &res);
+        free(big);
+        WF_CHECK(s == WF_ERR_HTTP);
+        expect_xrpc_error(&res, "InvalidRequest", "Too many writes. Max: 200");
+        wf_response_free(&res);
+    }
+
+    /* The one name the lexicon DOES define still comes back as itself. */
+    s = wf_xrpc_procedure(
+        client, "com.atproto.repo.createRecord",
+        "{\"repo\":\"did:plc:errnames\",\"collection\":\"com.example.posts\","
+        "\"swapCommit\":\"bafyreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\","
+        "\"record\":{\"text\":\"x\"}}", &res);
+    WF_CHECK(s == WF_ERR_HTTP);
+    expect_xrpc_error(&res, "InvalidSwap",
+                      "swap CID did not match current value");
+    wf_response_free(&res);
+
+    wf_xrpc_client_free(client);
+    wf_xrpc_server_free(server);
+    metalbear_repo_store_free(store);
+    unlink(path);
+    return failures;
+}
+
 int main(void) {
     run_unit();
     run_records_since_rev();
@@ -949,5 +1128,6 @@ int main(void) {
     run_adopted_key();
     run_did_immutability();
     run_server();
+    run_write_error_names();
     WF_TEST_SUMMARY();
 }


### PR DESCRIPTION
Two unrelated cleanups, one commit each.

## `fix(repo)` — write errors report lexicon names with precise messages

Eight TODOs in `src/repo_store.c` claimed atproto answers `InvalidRecordKey`,
`InvalidRecord` or `TooManyWrites`. None of those names exists.

Checked against `/Volumes/Storage/Developer/Local/atproto`:

- `com/atproto/repo/{createRecord,putRecord,deleteRecord,applyWrites}.json`
  each declare exactly one error, `InvalidSwap`. `getRecord.json` declares
  `RecordNotFound`. Nothing else.
- The names are absent from the lexicon corpus entirely. `InvalidRecordKeyError`
  exists only as a TypeScript class in `@atproto/syntax`, and
  `packages/pds/src/api/com/atproto/repo/createRecord.ts` converts it to
  `new InvalidRequestError(err.message)` — i.e. the wire error is
  `InvalidRequest`. Same for `InvalidRecordError`.
- `TooManyWrites` is not a class at all:
  `applyWrites.ts:86` is `throw new InvalidRequestError('Too many writes. Max: 200')`.

So acting on the TODOs would have emitted invented names, which AGENTS.md
explicitly warns against — as unusable to a client as a generic one and harder
to spot. They are removed, replaced by comments recording why the generic name
is correct.

Two message gaps are closed, so the precision sits where the reference puts it:

- `deleteRecord` now runs the same record-key check the other write routes run,
  answering `Invalid record key: <rkey>` instead of `record could not be
  deleted`.
- The `$type`-versus-collection check moves ahead of the `validate:false`
  shortcut. The reference performs it in `prepareWrite`, outside the
  `validateRecord` step that `validate:false` skips; gating it on validation
  meant a mismatched `$type` with `validate:false` fell through to the store's
  own guard and returned a bare `record creation failed`.

Covered end-to-end over HTTP in `test/test_repo_store.c`, asserting the error
name *and* message for all eight paths, plus the one name the lexicon does
define.

## `feat(metrics)` — the per-route table tracks the busiest routes

The table stopped accepting names at 128 and reported everything after that as
`other` for the life of the process. The bound is right — route names arrive
from the network, since the AppView proxy forwards arbitrary NSIDs, and an
unbounded label set is a memory-exhaustion lever — but freezing meant the
routes it named were whichever were seen first, so a method that became busy
after startup could never be named.

The bound stays; what happens at it changes. Storage is a fixed array sized at
a compile-time ceiling of 1024, and a full table gives the new name the
least-used row. That is self-defending: the coldest row is by definition one of
the one-request junk names already there, so a flood churns a single slot and
leaves a busy route untouched. Evicted counts move to `other`, so per-route
totals still sum to the overall request count exactly.

Capacity within the ceiling is configurable (`limits.metrics_max_routes` /
`METALBEAR_METRICS_MAX_ROUTES`, default 128, clamped). Configuration selects a
prefix of the fixed array; it can never make the table grow.

`test/test_metrics.c` is new and exercises the part nobody hits by accident: a
5000-name flood staying inside the bound with no request lost, a hot route
surviving that flood, a late route displacing a cold one, capacity clamping,
and shrinking the capacity without losing totals.

## Verification

`cmake -S . -B build -DWOLFRAM_SOURCE_DIR=... && cmake --build build && ctest`
is green at 15/15 (was 14/14; `metalbear_metrics` is the new one). No new
compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)