### PR TITLE
SECURITY: require an authenticated device session at /oauth/authorize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,15 @@ if(METALBEAR_BUILD_TESTS)
         "${METALBEAR_CJSON_SOURCE_DIR}")
     add_test(NAME metalbear_takedown COMMAND test_metalbear_takedown)
 
+    add_executable(test_metalbear_oauth_device_session
+        test/test_oauth_device_session.c)
+    target_link_libraries(test_metalbear_oauth_device_session PRIVATE
+        metalbear_core)
+    target_include_directories(test_metalbear_oauth_device_session PRIVATE
+        "${METALBEAR_CJSON_SOURCE_DIR}")
+    add_test(NAME metalbear_oauth_device_session
+        COMMAND test_metalbear_oauth_device_session)
+
     add_executable(test_metalbear_repo_store test/test_repo_store.c)
     target_link_libraries(test_metalbear_repo_store PRIVATE metalbear_core)
     target_include_directories(test_metalbear_repo_store PRIVATE

--- a/include/metalbear/oauth.h
+++ b/include/metalbear/oauth.h
@@ -84,6 +84,42 @@ wf_status metalbear_oauth_verify_request(
     const char *dpop_proof, const char *method, const char *uri,
     wf_oauth_verified_token **out);
 
+/*
+ * A device session: proof, held by a browser as a cookie, that this browser
+ * has already presented an account password once. `/oauth/authorize` is a
+ * plain page navigation with no Authorization header, so this is what a
+ * bearer token is everywhere else — the thing that lets the endpoint tell an
+ * authenticated browser apart from anyone who merely knows a handle.
+ *
+ * Deliberately outside the account/app-password credential system: a device
+ * session is bearer-by-cookie rather than bearer-by-header, lives 30 days,
+ * and is revoked by name rather than rotated. Folding it into
+ * metalbear_auth_store would give the browser session the refresh-rotation
+ * semantics an API client needs and a browser cookie does not.
+ */
+#define METALBEAR_DEVICE_SESSION_LIFETIME_SECONDS (30 * 24 * 60 * 60)
+
+/* Create a device session for `subject` (an account DID). *out_token is a
+ * caller-owned opaque bearer value; store it only as a cookie, never log or
+ * echo it. */
+wf_status metalbear_oauth_device_session_create(metalbear_oauth_store *store,
+                                                const char *subject,
+                                                char **out_token);
+
+/*
+ * Resolve a device session token to the account DID it was issued for.
+ * Writes into `out` (caller-supplied buffer) and returns WF_OK, or
+ * WF_ERR_NOT_FOUND if the token is unknown, expired, or NULL.
+ */
+wf_status metalbear_oauth_device_session_verify(metalbear_oauth_store *store,
+                                                const char *token, char *out,
+                                                size_t out_len);
+
+/* Revoke a device session. Revoking an unknown or already-expired token is
+ * WF_OK: the desired state — signed out — already holds. */
+wf_status metalbear_oauth_device_session_revoke(metalbear_oauth_store *store,
+                                                const char *token);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/metalbear/oauth_routes.h
+++ b/include/metalbear/oauth_routes.h
@@ -17,7 +17,9 @@ extern "C" {
  *   POST /oauth/par
  *   POST /oauth/token
  *   POST /oauth/revoke
- *   GET  /oauth/authorize */
+ *   GET  /oauth/authorize
+ *   POST /oauth/signin
+ *   POST /oauth/signout */
 /*
  * Resolve an account hint (a handle or DID supplied as `login_hint`) to the
  * account's DID. Writes it into `out` and returns 1, or returns 0 when no such
@@ -27,17 +29,33 @@ typedef int (*metalbear_oauth_subject_resolver)(void *ctx, const char *hint,
                                                 char *out, size_t out_len);
 
 /*
+ * Verify an account password (never an app password — see the note on
+ * /oauth/signin in oauth_routes.c for why) and resolve the account's DID.
+ * Writes it into `out` and returns 1 on success, 0 on any failure: unknown
+ * identifier, wrong password, or a credential that verified but was an app
+ * password rather than the account's own.
+ */
+typedef int (*metalbear_oauth_credential_verifier)(void *ctx,
+                                                    const char *identifier,
+                                                    const char *password,
+                                                    char *out, size_t out_len);
+
+/*
  * `resolve_subject` names which account an authorization is for. It is
  * required: with no privileged account there is no default identity to issue
  * a token for, and guessing one would hand a client somebody else's session.
+ *
+ * `verify_credential` is what makes `/oauth/authorize` safe to expose:
+ * without it, the endpoint would have no way to confirm that the browser
+ * asking for a code actually controls the account named by `login_hint`,
+ * and login_hint is not a secret — it is the same handle anyone can look up.
+ * Both callbacks receive `resolver_ctx`.
  */
-wf_status metalbear_oauth_routes_register(wf_xrpc_server *server,
-                                          metalbear_oauth_store *store,
-                                          const char *public_url,
-                                          const char *service_did,
-                                          metalbear_oauth_subject_resolver
-                                              resolve_subject,
-                                          void *resolver_ctx);
+wf_status metalbear_oauth_routes_register(
+    wf_xrpc_server *server, metalbear_oauth_store *store,
+    const char *public_url, const char *service_did,
+    metalbear_oauth_subject_resolver resolve_subject,
+    metalbear_oauth_credential_verifier verify_credential, void *resolver_ctx);
 
 #ifdef __cplusplus
 }

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -54,7 +54,7 @@ static wf_status token_hash(const char *token, unsigned char out[32]) {
 static void prune(metalbear_oauth_store *store, int64_t now) {
     sqlite3_stmt *stmt = NULL;
     static const char *const tables[] = {"oauth_par", "oauth_code",
-                                         "oauth_refresh"};
+                                         "oauth_refresh", "device_session"};
     for (size_t i = 0; i < sizeof(tables) / sizeof(tables[0]); i++) {
         char sql[96];
         int length = snprintf(sql, sizeof(sql),
@@ -200,9 +200,13 @@ wf_status metalbear_oauth_store_open(const char *path, const char *issuer,
             "CREATE TABLE IF NOT EXISTS oauth_refresh("
             "token_hash BLOB PRIMARY KEY,client_id TEXT NOT NULL,scope TEXT NOT NULL,"
             "dpop_jkt TEXT NOT NULL,subject TEXT NOT NULL,expires_at INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS device_session("
+            "token_hash BLOB PRIMARY KEY,subject TEXT NOT NULL,"
+            "expires_at INTEGER NOT NULL);"
             "CREATE INDEX IF NOT EXISTS oauth_par_expiry ON oauth_par(expires_at);"
             "CREATE INDEX IF NOT EXISTS oauth_code_expiry ON oauth_code(expires_at);"
-            "CREATE INDEX IF NOT EXISTS oauth_refresh_expiry ON oauth_refresh(expires_at);") != WF_OK ||
+            "CREATE INDEX IF NOT EXISTS oauth_refresh_expiry ON oauth_refresh(expires_at);"
+            "CREATE INDEX IF NOT EXISTS device_session_expiry ON device_session(expires_at);") != WF_OK ||
         load_or_create_key(store) != WF_OK ||
         wf_oauth_trusted_keys_new(&store->trusted_keys) != WF_OK ||
         wf_oauth_dpop_replay_cache_new(&store->replay) != WF_OK)
@@ -618,4 +622,99 @@ wf_status metalbear_oauth_verify_request(
         return WF_ERR_PERMISSION;
     }
     return WF_OK;
+}
+
+/* ── Device sessions ──────────────────────────────────────────────────── */
+
+wf_status metalbear_oauth_device_session_create(metalbear_oauth_store *store,
+                                                const char *subject,
+                                                char **out_token) {
+    if (!store || !subject || !subject[0] || !out_token)
+        return WF_ERR_INVALID_ARG;
+    *out_token = NULL;
+    char *token = NULL;
+    wf_status status = random_value(32, &token);
+    if (status != WF_OK) return status;
+    unsigned char hash[32];
+    if (token_hash(token, hash) != WF_OK) {
+        free(token);
+        return WF_ERR_CRYPTO;
+    }
+    int64_t expires_at =
+        (int64_t)time(NULL) + METALBEAR_DEVICE_SESSION_LIFETIME_SECONDS;
+
+    pthread_mutex_lock(&store->mutex);
+    prune(store, (int64_t)time(NULL));
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(store->db,
+            "INSERT INTO device_session(token_hash,subject,expires_at) "
+            "VALUES(?,?,?);", -1, &stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_blob(stmt, 1, hash, sizeof(hash), SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, subject, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(stmt, 3, expires_at);
+        status = sqlite3_step(stmt) == SQLITE_DONE ? WF_OK : WF_ERR_INTERNAL;
+    } else {
+        status = WF_ERR_INTERNAL;
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(&store->mutex);
+
+    if (status != WF_OK) {
+        free(token);
+        return status;
+    }
+    *out_token = token;
+    return WF_OK;
+}
+
+wf_status metalbear_oauth_device_session_verify(metalbear_oauth_store *store,
+                                                const char *token, char *out,
+                                                size_t out_len) {
+    if (!store || !out || out_len == 0) return WF_ERR_INVALID_ARG;
+    out[0] = '\0';
+    if (!token || !token[0]) return WF_ERR_NOT_FOUND;
+    unsigned char hash[32];
+    if (token_hash(token, hash) != WF_OK) return WF_ERR_CRYPTO;
+
+    pthread_mutex_lock(&store->mutex);
+    sqlite3_stmt *stmt = NULL;
+    wf_status status = WF_ERR_NOT_FOUND;
+    if (sqlite3_prepare_v2(store->db,
+            "SELECT subject FROM device_session "
+            "WHERE token_hash=? AND expires_at>?;", -1, &stmt,
+            NULL) == SQLITE_OK) {
+        sqlite3_bind_blob(stmt, 1, hash, sizeof(hash), SQLITE_TRANSIENT);
+        sqlite3_bind_int64(stmt, 2, (int64_t)time(NULL));
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            const char *subject = (const char *)sqlite3_column_text(stmt, 0);
+            if (subject) {
+                snprintf(out, out_len, "%s", subject);
+                status = WF_OK;
+            }
+        }
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(&store->mutex);
+    return status;
+}
+
+wf_status metalbear_oauth_device_session_revoke(metalbear_oauth_store *store,
+                                                const char *token) {
+    if (!store) return WF_ERR_INVALID_ARG;
+    if (!token || !token[0]) return WF_OK;   /* nothing to revoke */
+    unsigned char hash[32];
+    if (token_hash(token, hash) != WF_OK) return WF_ERR_CRYPTO;
+
+    pthread_mutex_lock(&store->mutex);
+    sqlite3_stmt *stmt = NULL;
+    wf_status status = WF_ERR_INTERNAL;
+    if (sqlite3_prepare_v2(store->db,
+            "DELETE FROM device_session WHERE token_hash=?;", -1, &stmt,
+            NULL) == SQLITE_OK) {
+        sqlite3_bind_blob(stmt, 1, hash, sizeof(hash), SQLITE_TRANSIENT);
+        status = sqlite3_step(stmt) == SQLITE_DONE ? WF_OK : WF_ERR_INTERNAL;
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(&store->mutex);
+    return status;
 }

--- a/src/oauth_routes.c
+++ b/src/oauth_routes.c
@@ -3,16 +3,67 @@
 #include "metalbear/oauth_routes.h"
 
 #include <cJSON.h>
+#include <curl/curl.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* The device-session cookie name and attributes. HttpOnly so a script on the
+ * page cannot read it (there is nothing legitimate for one to do with it, and
+ * XSS is the threat this defends against); SameSite=Lax rather than Strict so
+ * the cookie is still sent on the top-level navigation back from a sign-in
+ * redirect; Secure because the only real deployment is behind the reverse
+ * proxy the README already requires, terminating HTTPS. */
+#define MB_DEVICE_COOKIE "mb_device"
 
 typedef struct oauth_route_ctx {
     metalbear_oauth_store *store;
     char *public_url;
     metalbear_oauth_subject_resolver resolve_subject;
+    metalbear_oauth_credential_verifier verify_credential;
     void *resolver_ctx;
 } oauth_route_ctx;
+
+/* Percent-encode one query value. Caller frees with curl_free. */
+static char *url_escape(const char *value) {
+    return curl_easy_escape(NULL, value, 0);
+}
+
+/*
+ * Find `name=value` in a raw `Cookie` header (`name1=value1; name2=value2`,
+ * per RFC 6265) and return a copy of the value, or NULL if absent. MHD (and
+ * the shim) hand this over unparsed, the same way they hand over the rest of
+ * the request's headers.
+ */
+static char *find_cookie(const char *cookie_header, const char *name) {
+    if (!cookie_header) return NULL;
+    size_t name_len = strlen(name);
+    const char *p = cookie_header;
+    while (*p) {
+        while (*p == ' ' || *p == '\t') p++;
+        const char *eq = strchr(p, '=');
+        const char *semi = strchr(p, ';');
+        if (!eq || (semi && eq > semi)) {
+            if (!semi) break;
+            p = semi + 1;
+            continue;
+        }
+        const char *value_start = eq + 1;
+        const char *value_end = semi ? semi : value_start + strlen(value_start);
+        if ((size_t)(eq - p) == name_len && strncmp(p, name, name_len) == 0) {
+            size_t value_len = (size_t)(value_end - value_start);
+            char *out = malloc(value_len + 1);
+            if (!out) return NULL;
+            memcpy(out, value_start, value_len);
+            out[value_len] = '\0';
+            return out;
+        }
+        if (!semi) break;
+        p = semi + 1;
+    }
+    return NULL;
+}
 
 static wf_status json_response(wf_xrpc_response *resp, cJSON *root,
                                 const char *cache_control) {
@@ -305,6 +356,56 @@ static wf_status oauth_authorize(void *ctx, const wf_xrpc_request *req,
         return WF_OK;
     }
 
+    /*
+     * login_hint names the account, but it is not proof of anything: a
+     * handle is a public identifier, resolvable by anyone. What used to
+     * happen here is exactly the bug that made that a problem — a code was
+     * minted for whichever account login_hint named, no matter who was
+     * asking, which is an unauthenticated path to a valid token for any
+     * account on the host.
+     *
+     * The browser must additionally hold a device-session cookie proving it
+     * already presented that account's password once, in this browser,
+     * within the last 30 days. Absent one — first visit, expired, or one
+     * that names a different account than login_hint — no code is issued.
+     * The browser is redirected to sign in and land back here instead, with
+     * the same request_uri/client_id/login_hint it arrived with, so it can
+     * retry once the cookie is set.
+     */
+    char *device_token = find_cookie(req->cookie_header, MB_DEVICE_COOKIE);
+    char verified_subject[256];
+    bool authenticated =
+        device_token &&
+        metalbear_oauth_device_session_verify(
+            rctx->store, device_token, verified_subject,
+            sizeof(verified_subject)) == WF_OK &&
+        strcmp(verified_subject, subject) == 0;
+    free(device_token);
+
+    if (!authenticated) {
+        char *enc_ru = url_escape(request_uri);
+        char *enc_cid = url_escape(client_id);
+        char *enc_hint = url_escape(hint);
+        if (!enc_ru || !enc_cid || !enc_hint) {
+            curl_free(enc_ru); curl_free(enc_cid); curl_free(enc_hint);
+            return WF_ERR_ALLOC;
+        }
+        char redirect[1024];
+        int n = snprintf(redirect, sizeof(redirect),
+                         "/oauth/consent?request_uri=%s&client_id=%s&login_hint=%s",
+                         enc_ru, enc_cid, enc_hint);
+        curl_free(enc_ru); curl_free(enc_cid); curl_free(enc_hint);
+        if (n < 0 || (size_t)n >= sizeof(redirect)) {
+            wf_xrpc_response_set_error(resp, 400, "invalid_request",
+                                       "Request too large to continue");
+            return WF_OK;
+        }
+        wf_xrpc_response_set_content_type(resp, "text/html");
+        wf_xrpc_response_add_header(resp, "Location", redirect);
+        resp->http_status = 302;
+        return WF_OK;
+    }
+
     char *code = NULL;
     char *redirect_uri = NULL;
     char *state = NULL;
@@ -481,13 +582,105 @@ static wf_status oauth_revoke(void *ctx, const wf_xrpc_request *req,
     return json_response(resp, root, "no-store");
 }
 
-wf_status metalbear_oauth_routes_register(wf_xrpc_server *server,
-                                          metalbear_oauth_store *store,
-                                          const char *public_url,
-                                          const char *service_did,
-                                          metalbear_oauth_subject_resolver
-                                              resolve_subject,
-                                          void *resolver_ctx) {
+/* Build a `Set-Cookie` value for the device session and add it to `resp`.
+ * `max_age_seconds` of 0 clears the cookie, per RFC 6265. */
+static void set_device_cookie(wf_xrpc_response *resp, const char *token,
+                              int64_t max_age_seconds) {
+    char cookie[512];
+    snprintf(cookie, sizeof(cookie),
+            MB_DEVICE_COOKIE "=%s; Path=/; HttpOnly; Secure; SameSite=Lax; "
+            "Max-Age=%lld",
+            token ? token : "", (long long)max_age_seconds);
+    wf_xrpc_response_add_header(resp, "Set-Cookie", cookie);
+}
+
+/*
+ * POST /oauth/signin (not part of the OAuth spec) — the primitive both the
+ * plain account-login page and the OAuth consent page sign in through.
+ * Verifies an account password and, on success, sets the device-session
+ * cookie that `/oauth/authorize` requires.
+ *
+ * Account password only, never an app password. An app password is meant to
+ * carry restricted scope to one third-party client; if it could open a
+ * device session it could authorize this endpoint to grant OTHER OAuth
+ * clients access, or open the web UI to create further app passwords — a
+ * scoped credential escalating itself to full account control. That check
+ * lives in the verify_credential callback the caller supplies, not here:
+ * whether a given kind of credential counts as "the account's own" is an
+ * account-model question, not an OAuth-routing one.
+ */
+static wf_status oauth_signin(void *ctx, const wf_xrpc_request *req,
+                              wf_xrpc_response *resp) {
+    oauth_route_ctx *rctx = ctx;
+    if (!req->params || !cJSON_IsObject(req->params)) {
+        wf_xrpc_response_set_error(resp, 400, "invalid_request",
+                                   "Missing or invalid request body");
+        return WF_OK;
+    }
+    cJSON *identifier = cJSON_GetObjectItemCaseSensitive(req->params,
+                                                         "identifier");
+    cJSON *password = cJSON_GetObjectItemCaseSensitive(req->params,
+                                                       "password");
+    if (!cJSON_IsString(identifier) || !cJSON_IsString(password)) {
+        wf_xrpc_response_set_error(resp, 400, "invalid_request",
+                                   "identifier and password are required");
+        return WF_OK;
+    }
+
+    char subject[256];
+    if (!rctx->verify_credential ||
+        !rctx->verify_credential(rctx->resolver_ctx, identifier->valuestring,
+                                 password->valuestring, subject,
+                                 sizeof(subject))) {
+        /* Timing here is not constant, unlike com.atproto.server.createSession
+         * (which pads to 350ms). This endpoint is reached by a human typing
+         * into a form, not scriptable at a rate where that matters, and
+         * account_verify_credential's scrypt work already dominates any
+         * timing signal an unknown-vs-wrong-password branch could leak. */
+        wf_xrpc_response_set_error(resp, 401, "invalid_grant",
+                                   "Invalid identifier or password");
+        return WF_OK;
+    }
+
+    char *token = NULL;
+    if (metalbear_oauth_device_session_create(rctx->store, subject, &token) !=
+        WF_OK) {
+        wf_xrpc_response_set_error(resp, 500, "internal_error",
+                                   "Could not create a session");
+        return WF_OK;
+    }
+    set_device_cookie(resp, token, METALBEAR_DEVICE_SESSION_LIFETIME_SECONDS);
+    free(token);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) return WF_ERR_ALLOC;
+    cJSON_AddStringToObject(root, "did", subject);
+    return json_response(resp, root, "no-store");
+}
+
+/* POST /oauth/signout (not part of the OAuth spec). Revokes the presented
+ * device session, if any, and clears the cookie either way — the desired
+ * end state (signed out) holds whether or not there was a session to
+ * revoke. */
+static wf_status oauth_signout(void *ctx, const wf_xrpc_request *req,
+                               wf_xrpc_response *resp) {
+    oauth_route_ctx *rctx = ctx;
+    char *token = find_cookie(req->cookie_header, MB_DEVICE_COOKIE);
+    if (token) metalbear_oauth_device_session_revoke(rctx->store, token);
+    free(token);
+    set_device_cookie(resp, NULL, 0);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) return WF_ERR_ALLOC;
+    return json_response(resp, root, "no-store");
+}
+
+wf_status metalbear_oauth_routes_register(
+    wf_xrpc_server *server, metalbear_oauth_store *store,
+    const char *public_url, const char *service_did,
+    metalbear_oauth_subject_resolver resolve_subject,
+    metalbear_oauth_credential_verifier verify_credential,
+    void *resolver_ctx) {
     (void)service_did;
 
     if (!server || !store) return WF_ERR_INVALID_ARG;
@@ -497,6 +690,7 @@ wf_status metalbear_oauth_routes_register(wf_xrpc_server *server,
     ctx->store = store;
     ctx->public_url = public_url ? strdup(public_url) : NULL;
     ctx->resolve_subject = resolve_subject;
+    ctx->verify_credential = verify_credential;
     ctx->resolver_ctx = resolver_ctx;
 
     if (wf_xrpc_server_register_http_route(server, "GET",
@@ -514,7 +708,11 @@ wf_status metalbear_oauth_routes_register(wf_xrpc_server *server,
         wf_xrpc_server_register_http_route(server, "POST",
             "/oauth/revoke", oauth_revoke, ctx) != WF_OK ||
         wf_xrpc_server_register_http_route(server, "GET",
-            "/oauth/authorize", oauth_authorize, ctx) != WF_OK) {
+            "/oauth/authorize", oauth_authorize, ctx) != WF_OK ||
+        wf_xrpc_server_register_http_route(server, "POST",
+            "/oauth/signin", oauth_signin, ctx) != WF_OK ||
+        wf_xrpc_server_register_http_route(server, "POST",
+            "/oauth/signout", oauth_signout, ctx) != WF_OK) {
         free(ctx->public_url);
         free(ctx);
         return WF_ERR_INTERNAL;

--- a/src/server.c
+++ b/src/server.c
@@ -1268,6 +1268,40 @@ static int resolve_oauth_subject(void *ctx, const char *hint, char *out,
     return 1;
 }
 
+/*
+ * Verify credentials for a device session — /oauth/authorize's proof that
+ * the browser controls the account login_hint names, not merely that it
+ * knows the handle.
+ *
+ * Account password only. metalbear_account_verify_credential also accepts
+ * app passwords, which valid_login (createSession's own check) is right to
+ * allow: an app password is meant to open a session scoped to one
+ * third-party client. A device session is not that — it authorizes THIS
+ * endpoint to grant arbitrary OTHER OAuth clients access, and opens the web
+ * UI's account management including creating further app passwords. An app
+ * password that could open one would be a scoped credential escalating
+ * itself to full account control, so METALBEAR_CREDENTIAL_ACCOUNT is
+ * checked explicitly rather than accepting whatever
+ * metalbear_account_verify_credential accepted.
+ */
+static int verify_oauth_credential(void *ctx, const char *identifier,
+                                   const char *password, char *out,
+                                   size_t out_len) {
+    metalbear_server *server = ctx;
+    if (!server || !identifier || !identifier[0] || !password || !out ||
+        out_len == 0)
+        return 0;
+    metalbear_account_context *acct = context_for_identifier(server,
+                                                              identifier);
+    if (!acct || !acct->did || !acct->did[0]) return 0;
+    metalbear_credential_kind credential =
+        metalbear_account_verify_credential(acct->account, password, NULL);
+    if (credential != METALBEAR_CREDENTIAL_ACCOUNT) return 0;
+    if (strlen(acct->did) >= out_len) return 0;
+    snprintf(out, out_len, "%s", acct->did);
+    return 1;
+}
+
 /* ---- com.atproto.identity.getRecommendedDidCredentials (query) ---- */
 static wf_status get_recommended_did_credentials(void *ctx,
         const wf_xrpc_request *request, wf_xrpc_response *response) {
@@ -7211,6 +7245,7 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
                                          server->public_url,
                                          server->service_did,
                                          resolve_oauth_subject,
+                                         verify_oauth_credential,
                                          server) != WF_OK) {
         LOG_ERROR("cannot register OAuth routes");
         goto fail;

--- a/test/test_oauth.c
+++ b/test/test_oauth.c
@@ -93,6 +93,58 @@ int main(void) {
     free(code);
     free(redirect_uri);
     free(state);
+
+    /* Device sessions: the storage layer /oauth/authorize's gate depends on. */
+    {
+        char *token = NULL;
+        CHECK(metalbear_oauth_device_session_create(
+                  store, "did:plc:alice", &token) == WF_OK);
+        CHECK(token && token[0]);
+
+        char subject[256];
+        CHECK(metalbear_oauth_device_session_verify(
+                  store, token, subject, sizeof(subject)) == WF_OK);
+        CHECK(strcmp(subject, "did:plc:alice") == 0);
+
+        /* A token that never existed, and a token that did but was for a
+         * different subject entirely, must not be confused with each other —
+         * both simply fail. */
+        CHECK(metalbear_oauth_device_session_verify(
+                  store, "not-a-real-token", subject,
+                  sizeof(subject)) == WF_ERR_NOT_FOUND);
+        CHECK(metalbear_oauth_device_session_verify(
+                  store, NULL, subject, sizeof(subject)) == WF_ERR_NOT_FOUND);
+
+        /* Revoking clears it; the same token then verifies as absent, not as
+         * still valid for whoever it used to name. */
+        CHECK(metalbear_oauth_device_session_revoke(store, token) == WF_OK);
+        CHECK(metalbear_oauth_device_session_verify(
+                  store, token, subject, sizeof(subject)) ==
+              WF_ERR_NOT_FOUND);
+
+        /* Revoking a token that is already gone is success, not an error:
+         * the desired end state (signed out) already holds. */
+        CHECK(metalbear_oauth_device_session_revoke(store, token) == WF_OK);
+        CHECK(metalbear_oauth_device_session_revoke(store, "never-issued") ==
+              WF_OK);
+
+        /* Two accounts hold independent sessions; revoking one must not
+         * touch the other's. */
+        char *token_a = NULL, *token_b = NULL;
+        CHECK(metalbear_oauth_device_session_create(
+                  store, "did:plc:a", &token_a) == WF_OK);
+        CHECK(metalbear_oauth_device_session_create(
+                  store, "did:plc:b", &token_b) == WF_OK);
+        CHECK(metalbear_oauth_device_session_revoke(store, token_a) == WF_OK);
+        CHECK(metalbear_oauth_device_session_verify(
+                  store, token_b, subject, sizeof(subject)) == WF_OK);
+        CHECK(strcmp(subject, "did:plc:b") == 0);
+
+        free(token);
+        free(token_a);
+        free(token_b);
+    }
+
     metalbear_oauth_store_free(store);
     unlink(path);
     char sidecar[256];

--- a/test/test_oauth_device_session.c
+++ b/test/test_oauth_device_session.c
@@ -1,0 +1,350 @@
+#define _POSIX_C_SOURCE 200809L
+#define _DARWIN_C_SOURCE
+
+/*
+ * test_oauth_device_session.c — offline end-to-end coverage for the
+ * device-session gate on GET /oauth/authorize.
+ *
+ * `/oauth/authorize` used to mint an authorization code for whichever
+ * account `login_hint` named, with no check that the browser asking for it
+ * actually controlled that account — and a handle is a public identifier,
+ * not a secret, so this was an unauthenticated path to a valid OAuth token
+ * for any account on the host. This file proves that path is closed and
+ * that the legitimate flow around it still works:
+ *
+ *   (a) an authorize request naming a real account, with no device-session
+ *       cookie, is refused a code and redirected to sign in instead,
+ *   (b) /oauth/signin refuses a wrong password,
+ *   (c) /oauth/signin refuses an app password, even a correct one — a
+ *       device session is full account control (including creating further
+ *       app passwords), and an app password is meant to carry restricted
+ *       scope to one client; accepting one here would let a scoped
+ *       credential escalate itself,
+ *   (d) /oauth/signin accepts the account's own password and sets a
+ *       device-session cookie,
+ *   (e) authorize now succeeds with that cookie: it redirects to the
+ *       CLIENT's redirect_uri carrying a code and the original state,
+ *   (f) the same cookie does not authorize a DIFFERENT account,
+ *   (g) /oauth/signout revokes the session, and the same cookie value is
+ *       refused afterward.
+ *
+ * Cleanup removes the whole data directory.
+ */
+
+#include "metalbear/server.h"
+#include "wolfram/oauth.h"
+#include "wolfram/xrpc.h"
+
+#include <cJSON.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int rmtree_remove_cb(const char *path, const struct stat *sb,
+                            int type, struct FTW *ftwbuf) {
+    (void)sb; (void)type; (void)ftwbuf;
+    return remove(path);
+}
+static void rmtree(const char *path) {
+    nftw(path, rmtree_remove_cb, 64, FTW_DEPTH | FTW_PHYS);
+}
+
+static int failures;
+#define CHECK(expr) do { if (!(expr)) { \
+    fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); \
+    failures++; } } while (0)
+
+static cJSON *json_response(wf_response *response) {
+    return cJSON_ParseWithLength(response->body ? response->body : "",
+                                 response->body_len);
+}
+
+static bool body_has(const wf_response *response, const char *needle) {
+    if (!response || !response->body || !needle) return false;
+    size_t nlen = strlen(needle);
+    if (response->body_len < nlen) return false;
+    for (size_t i = 0; i + nlen <= response->body_len; i++)
+        if (memcmp(response->body + i, needle, nlen) == 0) return true;
+    return false;
+}
+
+static char *create_account(wf_xrpc_client *client, const char *handle,
+                            const char *did, const char *password) {
+    char body[512];
+    snprintf(body, sizeof(body),
+             "{\"handle\":\"%s\",\"password\":\"%s\",\"did\":\"%s\","
+             "\"email\":\"%s@example.com\"}",
+             handle, password, did, handle);
+    wf_response response = {0};
+    if (wf_xrpc_procedure(client, "com.atproto.server.createAccount", body,
+                          &response) != WF_OK || response.status != 200) {
+        wf_response_free(&response);
+        return NULL;
+    }
+    cJSON *json = json_response(&response);
+    cJSON *access = cJSON_GetObjectItemCaseSensitive(json, "accessJwt");
+    char *token = cJSON_IsString(access) ? strdup(access->valuestring) : NULL;
+    cJSON_Delete(json);
+    wf_response_free(&response);
+    return token;
+}
+
+/* Create an app password for the currently-authenticated account. */
+static char *create_app_password(wf_xrpc_client *client, const char *name) {
+    char body[128];
+    snprintf(body, sizeof(body), "{\"name\":\"%s\"}", name);
+    wf_response response = {0};
+    if (wf_xrpc_procedure(client, "com.atproto.server.createAppPassword",
+                          body, &response) != WF_OK ||
+        response.status != 200) {
+        wf_response_free(&response);
+        return NULL;
+    }
+    cJSON *json = json_response(&response);
+    cJSON *password = cJSON_GetObjectItemCaseSensitive(json, "password");
+    char *out = cJSON_IsString(password) ? strdup(password->valuestring)
+                                         : NULL;
+    cJSON_Delete(json);
+    wf_response_free(&response);
+    return out;
+}
+
+/* POST a JSON body with no Authorization header — every oauth route
+ * authenticates itself rather than going through the XRPC auth callback. */
+static wf_status oauth_post(wf_xrpc_client *client, const char *base,
+                            const char *path, const char *body,
+                            const wf_http_header *extra, size_t extra_count,
+                            wf_response *out) {
+    char url[256];
+    snprintf(url, sizeof(url), "%s%s", base, path);
+    return wf_http_post(client, url, "application/json", body, extra,
+                        extra_count, out);
+}
+
+/*
+ * Pull just `mb_device=<token>` out of a Set-Cookie value, discarding the
+ * `; Path=/; HttpOnly; ...` attributes — those are instructions to a real
+ * browser's cookie jar, not part of what a Cookie request header carries.
+ */
+static char *extract_cookie_pair(const char *set_cookie) {
+    if (!set_cookie) return NULL;
+    const char *semi = strchr(set_cookie, ';');
+    size_t len = semi ? (size_t)(semi - set_cookie) : strlen(set_cookie);
+    char *out = malloc(len + 1);
+    if (!out) return NULL;
+    memcpy(out, set_cookie, len);
+    out[len] = '\0';
+    return out;
+}
+
+int main(void) {
+    char directory[] = "/tmp/metalbear-oauth-device-XXXXXX";
+    CHECK(mkdtemp(directory) != NULL);
+    metalbear_config config = {
+        .listen_address = "127.0.0.1",
+        .port = 0,
+        .thread_count = 2,
+        .data_directory = directory,
+        .service_did = "did:web:pds.example.com",
+        .user_domain = ".example.com",
+        .admin_password = "secret-admin",
+        .invite_required = false,
+    };
+    metalbear_server *server = metalbear_server_start(&config);
+    CHECK(server != NULL);
+    if (!server) { rmtree(directory); return 1; }
+
+    char base[80];
+    snprintf(base, sizeof(base), "http://127.0.0.1:%u",
+             (unsigned)metalbear_server_port(server));
+    wf_xrpc_client *client = wf_xrpc_client_new(base);
+    CHECK(client != NULL);
+
+    const char *victim_did = "did:plc:victim";
+    const char *other_did = "did:plc:other";
+    char *victim_token = create_account(client, "victim.example.com",
+                                        victim_did, "victim-secret-pw");
+    char *other_token = create_account(client, "other.example.com",
+                                       other_did, "other-secret-pw");
+    CHECK(victim_token != NULL);
+    CHECK(other_token != NULL);
+    if (!victim_token || !other_token) goto done;
+
+    /* An app password for the privilege-escalation check, created through a
+     * real authenticated session — the same way a legitimate client would
+     * get one. */
+    wf_xrpc_client_set_auth(client, victim_token);
+    char *victim_app_password = create_app_password(client, "test-app");
+    CHECK(victim_app_password != NULL);
+    wf_xrpc_client_set_auth(client, NULL);
+
+    /* A PAR, exactly as a real OAuth client would push one. */
+    wf_oauth_pkce pkce = {0};
+    CHECK(wf_oauth_pkce_from_verifier(
+              "v3ry-long-test-verifier-with-enough-entropy-0123456789",
+              &pkce) == WF_OK);
+    char par_body[1024];
+    snprintf(par_body, sizeof(par_body),
+             "{\"client_id\":\"https://client.example/metadata.json\","
+             "\"redirect_uri\":\"https://client.example/callback\","
+             "\"scope\":\"atproto transition:generic\","
+             "\"state\":\"state-123\","
+             "\"code_challenge\":\"%s\","
+             "\"dpop_jkt\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}",
+             pkce.challenge);
+    wf_response response = {0};
+    CHECK(oauth_post(client, base, "/oauth/par", par_body, NULL, 0,
+                     &response) == WF_OK);
+    CHECK(response.status == 200);
+    cJSON *par_json = json_response(&response);
+    cJSON *request_uri_j = par_json
+        ? cJSON_GetObjectItemCaseSensitive(par_json, "request_uri") : NULL;
+    char request_uri[256] = "";
+    if (cJSON_IsString(request_uri_j))
+        snprintf(request_uri, sizeof(request_uri), "%s",
+                request_uri_j->valuestring);
+    CHECK(request_uri[0] != '\0');
+    cJSON_Delete(par_json);
+    wf_response_free(&response);
+
+    char authorize_url[512];
+    snprintf(authorize_url, sizeof(authorize_url),
+            "%s/oauth/authorize?request_uri=%s&client_id=https%%3A%%2F%%2F"
+            "client.example%%2Fmetadata.json&login_hint=victim.example.com",
+            base, request_uri);
+
+    /* ---- (a) unauthenticated: the vulnerability, now closed ------------ */
+    {
+        wf_status s = wf_http_get_with_headers(client, authorize_url, NULL,
+                                               0, &response);
+        CHECK(s == WF_ERR_HTTP);
+        CHECK(response.status == 302);
+        /* Sent to sign in, not handed a code. */
+        CHECK(response.location != NULL);
+        CHECK(response.location &&
+              strncmp(response.location, "/oauth/consent?", strlen("/oauth/consent?")) == 0);
+        CHECK(response.location && strstr(response.location, "login_hint="));
+        /* The one thing that must never appear here: a live authorization
+         * code for an account nobody has proven they control. */
+        CHECK(!(response.location && strstr(response.location, "code=")));
+        wf_response_free(&response);
+    }
+
+    /* ---- (b) wrong password ---------------------------------------------*/
+    {
+        const char *body =
+            "{\"identifier\":\"victim.example.com\",\"password\":\"wrong\"}";
+        CHECK(oauth_post(client, base, "/oauth/signin", body, NULL, 0,
+                         &response) == WF_ERR_HTTP);
+        CHECK(response.status == 401);
+        CHECK(response.set_cookie == NULL);
+        wf_response_free(&response);
+    }
+
+    /* ---- (c) an app password must not open a device session ------------ */
+    if (victim_app_password) {
+        char body[256];
+        snprintf(body, sizeof(body),
+                "{\"identifier\":\"victim.example.com\",\"password\":\"%s\"}",
+                victim_app_password);
+        wf_status s = oauth_post(client, base, "/oauth/signin", body, NULL,
+                                 0, &response);
+        CHECK(s == WF_ERR_HTTP);
+        CHECK(response.status == 401);
+        CHECK(response.set_cookie == NULL);
+        wf_response_free(&response);
+    }
+
+    /* ---- (d) the account's own password succeeds ------------------------*/
+    char *device_cookie = NULL;
+    {
+        const char *body = "{\"identifier\":\"victim.example.com\","
+                           "\"password\":\"victim-secret-pw\"}";
+        CHECK(oauth_post(client, base, "/oauth/signin", body, NULL, 0,
+                         &response) == WF_OK);
+        CHECK(response.status == 200);
+        CHECK(response.set_cookie != NULL);
+        CHECK(response.set_cookie && strstr(response.set_cookie, "mb_device="));
+        CHECK(response.set_cookie && strstr(response.set_cookie, "HttpOnly"));
+        CHECK(body_has(&response, "\"did\":\"did:plc:victim\""));
+        device_cookie = extract_cookie_pair(response.set_cookie);
+        wf_response_free(&response);
+    }
+    CHECK(device_cookie != NULL);
+
+    /* ---- (e) authorize now succeeds, cookie now set ---------------------*/
+    if (device_cookie) {
+        wf_http_header hdr = {"Cookie", device_cookie};
+        wf_status s = wf_http_get_with_headers(client, authorize_url, &hdr, 1,
+                                               &response);
+        CHECK(s == WF_ERR_HTTP);
+        CHECK(response.status == 302);
+        CHECK(response.location != NULL);
+        CHECK(response.location &&
+              strncmp(response.location, "https://client.example/callback",
+                     strlen("https://client.example/callback")) == 0);
+        CHECK(response.location && strstr(response.location, "code="));
+        CHECK(response.location && strstr(response.location, "state=state-123"));
+        wf_response_free(&response);
+    }
+
+    /* ---- (f) the same cookie does not authorize a different account -----*/
+    if (device_cookie) {
+        char other_url[512];
+        snprintf(other_url, sizeof(other_url),
+                "%s/oauth/authorize?request_uri=%s&client_id=https%%3A%%2F%%2F"
+                "client.example%%2Fmetadata.json&login_hint=other.example.com",
+                base, request_uri);
+        wf_http_header hdr = {"Cookie", device_cookie};
+        wf_status s = wf_http_get_with_headers(client, other_url, &hdr, 1,
+                                               &response);
+        CHECK(s == WF_ERR_HTTP);
+        CHECK(response.status == 302);
+        CHECK(response.location != NULL);
+        CHECK(response.location &&
+              strncmp(response.location, "/oauth/consent?", strlen("/oauth/consent?")) == 0);
+        CHECK(!(response.location && strstr(response.location, "code=")));
+        wf_response_free(&response);
+    }
+
+    /* ---- (g) signout revokes it ------------------------------------------*/
+    if (device_cookie) {
+        wf_http_header hdr = {"Cookie", device_cookie};
+        CHECK(oauth_post(client, base, "/oauth/signout", "{}", &hdr, 1,
+                         &response) == WF_OK);
+        CHECK(response.status == 200);
+        CHECK(response.set_cookie != NULL);
+        CHECK(response.set_cookie && strstr(response.set_cookie, "Max-Age=0"));
+        wf_response_free(&response);
+
+        /* The old cookie value, now revoked, must be refused just like no
+         * cookie at all — not merely rejected by Max-Age on a browser that
+         * has already stopped sending it. */
+        wf_status s = wf_http_get_with_headers(client, authorize_url, &hdr, 1,
+                                               &response);
+        CHECK(s == WF_ERR_HTTP);
+        CHECK(response.status == 302);
+        CHECK(response.location != NULL);
+        CHECK(response.location &&
+              strncmp(response.location, "/oauth/consent?", strlen("/oauth/consent?")) == 0);
+        wf_response_free(&response);
+    }
+
+done:
+    free(device_cookie);
+    free(victim_app_password);
+    free(victim_token);
+    free(other_token);
+    if (client) wf_xrpc_client_free(client);
+    metalbear_server_free(server);
+    rmtree(directory);
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("test_oauth_device_session: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## The vulnerability

`GET /oauth/authorize` minted a valid OAuth authorization code for whichever
account `login_hint` named, with **no check that the requester controlled that
account**. `login_hint` is not a secret — it's the same handle
`com.atproto.identity.resolveHandle` resolves for anyone — so this was an
unauthenticated path to a valid access token for **any account on the host**.
Live since the endpoint was added (20 Jul), present in the deployed 0.7.0, on
a publicly federated host.

The root cause: `wf_xrpc_server_register_http_route` bypasses the XRPC auth
callback entirely (by design — HTTP routes handle their own auth), and
`/oauth/authorize`'s own handler never did. The reference oauth-provider only
ever mints a code against an existing authenticated *device session*
(`accountManager.listDeviceAccounts(deviceId)`); this endpoint had no
equivalent and trusted `login_hint` alone.

## The fix

A device session: a cookie proving this browser presented an account's
password once, within the last 30 days. `/oauth/authorize` now requires one
matching the account `login_hint` names — absent, expired, or naming a
different account, and it redirects to `/oauth/consent` (frontend, to be
built) instead of minting a code, carrying the same `request_uri` /
`client_id` / `login_hint` so the browser can retry once signed in.

Two new endpoints make that possible:
- `POST /oauth/signin` — verifies a password, sets the cookie
- `POST /oauth/signout` — revokes it

**Account password only, never an app password.** A device session is full
account control (including creating further app passwords); an app password
that could open one would be a scoped credential escalating itself. Checked
explicitly (`METALBEAR_CREDENTIAL_ACCOUNT`), not inferred from whatever
`metalbear_account_verify_credential` happened to accept.

## Wolfram groundwork (all merged to main)

Three small, precedented additions — each mirrors a field the codebase
already had for the same reason (`auth_header`/`dpop_header` on the request,
`dpop_nonce` on the response):
- ewanc26/wolfram#15 — `cookie_header` on `wf_xrpc_request`
- ewanc26/wolfram#16 — `set_cookie` and `location` on `wf_response`

Each merged only after 137→138/138 and a **mutation check**: reverting the
one line that wires the new field in fails the new test with a NULL
mismatch, confirming the assertion pins real wiring rather than passing
regardless.

## Verification

- 15/15 `ctest`, clean build, no new compiler warnings (one `/*`-in-comment
  warning caught and fixed before merge)
- **The new end-to-end test proves the exploit path is closed**, not just
  that new code runs: unauthenticated authorize → redirected, not issued a
  code; wrong password → refused; a real app password → refused; the
  account's own password → cookie set → authorize now succeeds, redirecting
  to the *client* with a code and the original `state`; the same cookie does
  **not** authorize a different account; signout revokes it and the same
  cookie is refused afterward
- **Mutation-checked the whole gate**: removing it entirely fails 14 of the
  new test's assertions immediately — the test does not pass by accident
- Leak-checked: 8 leaks / 912 bytes in the new test, all in pre-existing
  server-lifecycle/MHD-thread paths (confirmed by running `leaks` against an
  already-merged test, `test_takedown`, which shows *more* — 22/2000 — through
  the identical paths). Nothing new-code-shaped.

## What this does not do

`/oauth/consent` — the frontend page a blocked authorize request redirects
to, where the user actually signs in — does not exist yet. Until it does, an
OAuth client hitting this host cannot complete authorization at all (it was
previously succeeding *insecurely*; it now fails *safely*, which is the
correct tradeoff, but it is a regression in what works today). That's the
next piece of work.

## Recommendation

Given the live exposure window, I'd suggest reviewing and merging this
promptly. I have **not** deployed it to the dev instance — that's a call I'm
leaving to you given the security nature of the change, but I'd flag that
every hour it's not deployed is an hour the vulnerability stays live on
`bear1.croft.click`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lahd4tPa1cWFhQB4YXPvwH