### PR TITLE
fix(video): align limits and project metadata with current code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
-project(metalbear VERSION 0.39.1 LANGUAGES C CXX)
+project(
+  metalbear
+  VERSION 0.39.1
+  DESCRIPTION "A C23-first AT Protocol Personal Data Server with isolated C++ modules"
+  LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# MetalBear — an AT Protocol Personal Data Server in C23.
+# MetalBear — a C23-first AT Protocol Personal Data Server with isolated C++ modules.
 #
 # The build context is the parent directory holding both the MetalBear and
 # Wolfram source trees, so the image always builds the SDK from the same commit
@@ -103,7 +103,7 @@ CMD ["/bin/bash"]
 FROM debian:bookworm-slim AS runtime
 
 LABEL org.opencontainers.image.title="MetalBear" \
-      org.opencontainers.image.description="An AT Protocol Personal Data Server written in C23" \
+      org.opencontainers.image.description="A C23-first AT Protocol Personal Data Server with isolated C++ modules" \
       org.opencontainers.image.source="https://github.com/ewanc26/metalbear" \
       org.opencontainers.image.licenses="AGPL-3.0-only"
 RUN apt-get update     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ MetalBear is an AT Protocol Personal Data Server written in C23 and built on
 [Wolfram](https://github.com/ewanc26/wolfram). C is the default language;
 C++ is used for complex or sensitive components where C is insufficient —
 RAII-based resource management (e.g. sqlite3), performance-critical code,
-and third-party library integrations. All C++ code exposes a C ABI via
-`extern "C"` so the SDK never requires a C++ toolchain at runtime.
+and third-party library integrations. The public boundary remains a C ABI via
+`extern "C"`; building MetalBear requires both C and C++ compilers, while the
+shipped Linux binary statically carries its C++ runtime support.
 It hosts multiple accounts, mints `did:plc` identities, serves the firehose,
 and federates: as of 0.4.1 a MetalBear instance is consumed by Bluesky's
 relays and its posts are indexed by the Bluesky AppView.
@@ -38,9 +39,9 @@ relays and its posts are indexed by the Bluesky AppView.
   writes, and CAR import
 - public record reads, collection listing, repo description, and latest commit
 - full or revision-filtered CAR repository export and CID-selected block export
-- public repository status, single-account repository enumeration, and
-  `com.atproto.sync.listBlobs` enumeration (backed by Wolfram's
-  `wf_blob_store_list`, with limit/cursor pagination)
+- public repository status, multi-account repository enumeration, and
+  `com.atproto.sync.listBlobs` enumeration (backed by MetalBear's file-backed
+  blob store, with limit/cursor pagination)
 - durable `com.atproto.sync.subscribeRepos` sequencing with live commit events,
   cursor replay across restarts, import sync events, and `FutureCursor` errors
 - `com.atproto.identity.resolveHandle`, `/.well-known/atproto-did` handle

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -46,7 +46,7 @@
 	<title>MetalBear{hostname ? ` — ${hostname}` : ''}</title>
 	<meta
 		name="description"
-		content="A Personal Data Server for the AT Protocol, written in pure C23."
+		content="A C23-first Personal Data Server for the AT Protocol with isolated C++ modules."
 	/>
 </svelte:head>
 

--- a/include/metalbear/video.h
+++ b/include/metalbear/video.h
@@ -1,0 +1,9 @@
+#ifndef METALBEAR_VIDEO_H
+#define METALBEAR_VIDEO_H
+
+#include <stdint.h>
+
+/* app.bsky.embed.video#main's current blob maximum, in decimal bytes. */
+#define METALBEAR_VIDEO_MAX_BYTES UINT64_C(300000000)
+
+#endif /* METALBEAR_VIDEO_H */

--- a/src/video/video_routes.c
+++ b/src/video/video_routes.c
@@ -15,6 +15,7 @@
 #include "../server_internal.h"
 
 #include "metalbear/log.h"
+#include "metalbear/video.h"
 #include "metalbear/account/account_context.h"
 #include "metalbear/ops/metrics.h"
 #include "metalbear/repo/blob_store.h"
@@ -25,9 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-/* app.bsky.embed.video#main's video blob accepts up to 100mb. */
-#define METALBEAR_VIDEO_MAX_BYTES (100u * 1024u * 1024u)
 
 /* job ID layout: vid-<unix_ts>-<cid>-<size>; the CID alphabet (base32
  * lower) contains no '-', so a dash is an unambiguous field separator. */
@@ -86,7 +84,7 @@ wf_status video_upload(void *ctx, const wf_xrpc_request *request,
     }
     if (request->body_len > METALBEAR_VIDEO_MAX_BYTES) {
         wf_xrpc_response_set_error(response, 413, "InvalidRequest",
-                                   "video exceeds the 100MB upload limit");
+                                   "video exceeds the 300MB upload limit");
         return WF_OK;
     }
     const char *mime = request->content_type && request->content_type[0]

--- a/test/test_server.c
+++ b/test/test_server.c
@@ -4,6 +4,7 @@
 #endif
 #include "metalbear/server.h"
 #include "metalbear/account/account_registry.h"
+#include "metalbear/video.h"
 #include "wolfram/repo/car.h"
 #include "wolfram/sync_subscribe.h"
 #include "wolfram/xrpc.h"
@@ -1609,6 +1610,7 @@ int main(void) {
 
     /* app.bsky.video.uploadVideo: store the video as a blob and return an
      * immediately-completed jobStatus carrying the blob ref. */
+    CHECK(METALBEAR_VIDEO_MAX_BYTES == UINT64_C(300000000));
     const unsigned char video_data[] = {
         0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm',
     };


### PR DESCRIPTION
## Summary

- align the legacy video upload ceiling with the current official `app.bsky.embed.video` maximum of 300,000,000 decimal bytes
- expose that limit from a small C module header and pin it in the existing server regression suite
- add accurate CMake project metadata
- correct README claims about multi-account enumeration, MetalBear-owned blob storage, and the C/C++ build/runtime boundary
- align OCI and frontend descriptions with the C23-first implementation and isolated C++ modules

## Raspberry Pi / stability impact

- no additional resident payload buffering or background work
- one compile-time constant only; the upload implementation retains its existing single-payload processing model
- metadata now accurately states that builds require both C and C++ compilers while the shipped Linux binary statically carries C++ runtime support

## Verification

- clang-format 18 on changed C/header files
- `git diff --check`
- the regression is part of `test_metalbear`; full local configure is unavailable because this sandbox lacks SQLite development headers, so GitHub Actions is the authoritative full build/test run
