### PR TITLE
perf(account): bound resident account contexts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ if(METALBEAR_BUILD_TESTS)
                              PRIVATE "${WOLFRAM_SOURCE_DIR}/test")
   add_test(NAME metalbear_video_upload COMMAND test_metalbear_video_upload)
 
+  add_executable(test_metalbear_account_cache test/test_account_cache.c)
+  target_link_libraries(test_metalbear_account_cache PRIVATE metalbear_core)
+  add_test(NAME metalbear_account_cache COMMAND test_metalbear_account_cache)
+
   add_executable(test_metalbear_config_file test/test_config_file.c)
   target_link_libraries(test_metalbear_config_file PRIVATE metalbear_core)
   target_include_directories(test_metalbear_config_file

--- a/README.md
+++ b/README.md
@@ -494,6 +494,14 @@ authority across rebuilds. A configured key that cannot be parsed is fatal
 rather than silently replaced, because every DID minted with a substitute key
 would be unrecoverable.
 
+`METALBEAR_MAX_RESIDENT_ACCOUNTS` bounds how many idle (fully released) account
+contexts the server keeps open at once; the least-recently-used idle accounts
+are closed past this limit and reopened on demand, so memory no longer grows
+with the total number of accounts ever touched. The default (256) is safe for a
+general host; on a 256 MB Raspberry Pi 1B, where each context carries a SQLite
+repo and blob store, lower it to something like 16–32 and watch the
+`metalbear_account_cache_resident` gauge on `GET /metrics`.
+
 `METALBEAR_INVITE_REQUIRED` defaults to true. Mint a code with admin HTTP Basic
 auth, then create the first account with it:
 

--- a/include/metalbear/account/account_cache.h
+++ b/include/metalbear/account/account_cache.h
@@ -6,6 +6,7 @@
 #include "metalbear/account/account_registry.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,10 +14,22 @@ extern "C" {
 
 typedef struct metalbear_account_cache metalbear_account_cache;
 
-/* Create a cache of open per-account store bundles. The cache owns the
- * contexts it opens and keeps them alive for the server lifetime, so the
- * pointers it returns are stable for the duration of any request that uses
- * them (this is what the wolfram per-request repo/blob resolver needs). */
+/*
+ * A bounded cache of open per-account store bundles.
+ *
+ * Every account context this cache opens is reference-counted. A call to
+ * metalbear_account_cache_get acquires one reference and returns the context;
+ * the matching metalbear_account_cache_release (or, for request-bound use,
+ * metalbear_account_cache_release_thread_local at request end) drops it. The
+ * cache never frees a context whose reference count is still above zero, so a
+ * handler that is still using a context can never observe a use-after-free.
+ *
+ * Idle (fully-released) contexts are evicted under a configurable resident
+ * budget, least-recently-used first, so memory no longer grows without bound
+ * with the number of accounts ever touched. Durable account state lives in
+ * each account's own data directory and is reopened on the next get, so
+ * eviction is transparent to callers.
+ */
 metalbear_account_cache *
 metalbear_account_cache_new(const char *service_did, const char *public_url,
                             const char *data_directory);
@@ -28,15 +41,67 @@ metalbear_account_cache_new(const char *service_did, const char *public_url,
  * their own per-account logs, which nothing serves. */
 void metalbear_account_cache_set_sequencer(metalbear_account_cache *cache,
                                            metalbear_sequencer *sequencer);
+
+/*
+ * Configure the resident budget: the maximum number of idle (fully released)
+ * account contexts the cache will keep open at once. When the idle count
+ * exceeds `max_resident`, the least-recently-used idle contexts are closed
+ * until it is back under budget. A context still referenced by a request is
+ * never evicted regardless of this limit.
+ *
+ * `max_resident` of 0 selects a conservative default. On a 256 MB Raspberry Pi
+ * 1B, each account context carries a SQLite repo store and blob store; set
+ * this low (e.g. 16–32) and watch the account_cache_resident gauge.
+ */
+void metalbear_account_cache_set_max_resident(metalbear_account_cache *cache,
+                                              size_t max_resident);
+
 void metalbear_account_cache_free(metalbear_account_cache *cache);
 
-/* Return the open context for `did`, opening it on first use. The returned
- * context is owned by the cache and must NOT be freed by the caller. Returns
- * NULL when the account is unknown to `registry` or cannot be opened. */
+/*
+ * Return the open context for `did`, opening it on first use, and acquire a
+ * reference on it. The caller must release the reference exactly once when the
+ * context is no longer needed — either with metalbear_account_cache_release,
+ * or, for contexts used only for the duration of a request, by calling
+ * metalbear_account_cache_release_thread_local at request end (the MetalBear
+ * server wires this to the XRPC request observer, so ordinary route handlers
+ * never release by hand). Returns NULL when the account is unknown to
+ * `registry` or cannot be opened.
+ */
 metalbear_account_context *
 metalbear_account_cache_get(metalbear_account_cache *cache,
                             metalbear_account_registry *registry,
                             const char *did);
+
+/*
+ * Drop a single reference acquired by metalbear_account_cache_get. When the
+ * last reference is released the context becomes evictable; if the resident
+ * budget is exceeded it may be closed immediately. Safe to call once per
+ * acquired reference; passing a context not owned by `cache` is a no-op.
+ */
+void metalbear_account_cache_release(metalbear_account_cache *cache,
+                                     metalbear_account_context *ctx);
+
+/*
+ * Release every reference this thread has acquired since the last call. The
+ * MetalBear server calls this from its XRPC request observer, so route
+ * handlers that resolve accounts through the request path never manage
+ * references by hand. Calling it from a thread that made no acquisitions is a
+ * no-op. Not safe to call concurrently with a handler still using a context on
+ * the same thread — only invoke it once the request has fully completed.
+ */
+void metalbear_account_cache_release_thread_local(void);
+
+/*
+ * Snapshot of cache health for operational metrics. `resident` is the total
+ * number of open contexts (referenced or idle), `idle` the number fully
+ * released and therefore evictable, `evictions`/`hits`/`misses` are monotonic
+ * counters since the cache was created. Any pointer may be NULL.
+ */
+void metalbear_account_cache_stats(metalbear_account_cache *cache,
+                                   size_t *resident, size_t *idle,
+                                   uint64_t *evictions, uint64_t *hits,
+                                   uint64_t *misses);
 
 #ifdef __cplusplus
 }

--- a/include/metalbear/ops/metrics.h
+++ b/include/metalbear/ops/metrics.h
@@ -51,6 +51,13 @@ typedef enum metalbear_metric {
     METALBEAR_METRIC_DNS_FAILURES,
     /* A relay that could not be told there was new data. */
     METALBEAR_METRIC_CRAWL_FAILURES,
+    /* Account cache: a context already open was reused, a context had to be
+     * opened (miss), and an idle context was closed to stay under the resident
+     * budget. Residency itself (resident/idle counts) is a gauge read from the
+     * cache at scrape time, not a counter. */
+    METALBEAR_METRIC_ACCOUNT_CACHE_HITS,
+    METALBEAR_METRIC_ACCOUNT_CACHE_MISSES,
+    METALBEAR_METRIC_ACCOUNT_CACHE_EVICTIONS,
     METALBEAR_METRIC_COUNT
 } metalbear_metric;
 

--- a/src/account/account_cache.c
+++ b/src/account/account_cache.c
@@ -2,9 +2,23 @@
 
 #include "metalbear/account/account_cache.h"
 
+#include "metalbear/ops/metrics.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
+
+/* Forward declaration: get() records each acquisition so the request observer
+ * can release it via metalbear_account_cache_release_thread_local. */
+void account_cache_push_acquired(metalbear_account_cache *cache,
+                                 metalbear_account_context *ctx);
+
+/* Conservative default resident budget. Each cached account holds a SQLite
+ * repo store plus a blob store; on a 256 MB Pi 1B this should be lowered via
+ * metalbear_account_cache_set_max_resident (the daemon reads
+ * METALBEAR_MAX_RESIDENT_ACCOUNTS). */
+#define ACCOUNT_CACHE_DEFAULT_MAX_RESIDENT 256
 
 struct metalbear_account_cache {
     char *service_did;
@@ -17,7 +31,19 @@ struct metalbear_account_cache {
         char *did;
         metalbear_account_context *ctx;
         struct cache_entry *next;
+        /* Number of live references (get acquisitions not yet released). */
+        int refcount;
+        /* Monotonic LRU timestamp; lower means evicted first when idle. */
+        unsigned long seq;
     } *entries;
+    /* Bumped on every touch so idle eviction can pick the oldest. */
+    unsigned long seq_counter;
+    size_t idle_count;
+    size_t total_count;
+    size_t max_resident;
+    _Atomic uint64_t evictions;
+    _Atomic uint64_t hits;
+    _Atomic uint64_t misses;
 };
 
 metalbear_account_cache *
@@ -37,12 +63,22 @@ metalbear_account_cache_new(const char *service_did, const char *public_url,
         free(cache);
         return NULL;
     }
+    cache->max_resident = ACCOUNT_CACHE_DEFAULT_MAX_RESIDENT;
     return cache;
 }
 
 void metalbear_account_cache_set_sequencer(metalbear_account_cache *cache,
                                            metalbear_sequencer *sequencer) {
     if (cache) cache->sequencer = sequencer;
+}
+
+void metalbear_account_cache_set_max_resident(metalbear_account_cache *cache,
+                                              size_t max_resident) {
+    if (!cache) return;
+    pthread_mutex_lock(&cache->lock);
+    cache->max_resident =
+        max_resident ? max_resident : ACCOUNT_CACHE_DEFAULT_MAX_RESIDENT;
+    pthread_mutex_unlock(&cache->lock);
 }
 
 void metalbear_account_cache_free(metalbear_account_cache *cache) {
@@ -64,6 +100,47 @@ void metalbear_account_cache_free(metalbear_account_cache *cache) {
     free(cache);
 }
 
+/*
+ * Close and unlink `victim` (must already be unlinked by the caller). Caller
+ * holds cache->lock.
+ */
+static void entry_close(struct cache_entry *victim) {
+    free(victim->did);
+    metalbear_account_context_close(victim->ctx);
+    free(victim);
+}
+
+/*
+ * Evict the least-recently-used idle (refcount == 0) entry if the idle count
+ * is over budget. Caller holds cache->lock.
+ */
+static void evict_if_over_budget_locked(metalbear_account_cache *cache) {
+    while (cache->idle_count > cache->max_resident && cache->entries) {
+        struct cache_entry *oldest = NULL;
+        struct cache_entry *oldest_prev = NULL;
+        struct cache_entry *prev = NULL;
+        for (struct cache_entry *e = cache->entries; e; e = e->next) {
+            if (e->refcount != 0) continue;
+            if (!oldest || e->seq < oldest->seq) {
+                oldest = e;
+                oldest_prev = prev;
+            }
+            prev = e;
+        }
+        if (!oldest) break; /* nothing idle to evict */
+
+        if (oldest_prev)
+            oldest_prev->next = oldest->next;
+        else
+            cache->entries = oldest->next;
+
+        cache->idle_count--;
+        cache->total_count--;
+        atomic_fetch_add_explicit(&cache->evictions, 1, memory_order_relaxed);
+        entry_close(oldest);
+    }
+}
+
 metalbear_account_context *
 metalbear_account_cache_get(metalbear_account_cache *cache,
                             metalbear_account_registry *registry,
@@ -73,8 +150,13 @@ metalbear_account_cache_get(metalbear_account_cache *cache,
     pthread_mutex_lock(&cache->lock);
     for (struct cache_entry *e = cache->entries; e; e = e->next) {
         if (strcmp(e->did, did) == 0) {
+            if (e->refcount == 0) cache->idle_count--;
+            e->refcount++;
+            e->seq = ++cache->seq_counter;
             metalbear_account_context *ctx = e->ctx;
             pthread_mutex_unlock(&cache->lock);
+            atomic_fetch_add_explicit(&cache->hits, 1, memory_order_relaxed);
+            account_cache_push_acquired(cache, ctx);
             return ctx;
         }
     }
@@ -100,9 +182,14 @@ metalbear_account_cache_get(metalbear_account_cache *cache,
     /* Re-check after re-acquiring the lock in case another thread won. */
     for (struct cache_entry *e = cache->entries; e; e = e->next) {
         if (strcmp(e->did, did) == 0) {
+            if (e->refcount == 0) cache->idle_count--;
+            e->refcount++;
+            e->seq = ++cache->seq_counter;
             metalbear_account_context *existing = e->ctx;
             pthread_mutex_unlock(&cache->lock);
             metalbear_account_context_close(ctx);
+            atomic_fetch_add_explicit(&cache->hits, 1, memory_order_relaxed);
+            account_cache_push_acquired(cache, existing);
             return existing;
         }
     }
@@ -113,9 +200,100 @@ metalbear_account_cache_get(metalbear_account_cache *cache,
         return NULL;
     }
     ne->did = strdup(did);
+    if (!ne->did) {
+        pthread_mutex_unlock(&cache->lock);
+        free(ne);
+        metalbear_account_context_close(ctx);
+        return NULL;
+    }
     ne->ctx = ctx;
+    ne->refcount = 1;
+    ne->seq = ++cache->seq_counter;
     ne->next = cache->entries;
     cache->entries = ne;
+    cache->total_count++;
+    evict_if_over_budget_locked(cache);
     pthread_mutex_unlock(&cache->lock);
+    atomic_fetch_add_explicit(&cache->misses, 1, memory_order_relaxed);
+    account_cache_push_acquired(cache, ctx);
     return ctx;
+}
+
+void metalbear_account_cache_release(metalbear_account_cache *cache,
+                                     metalbear_account_context *ctx) {
+    if (!cache || !ctx) return;
+    pthread_mutex_lock(&cache->lock);
+    for (struct cache_entry *e = cache->entries; e; e = e->next) {
+        if (e->ctx == ctx) {
+            if (e->refcount > 0) {
+                e->refcount--;
+                if (e->refcount == 0) {
+                    cache->idle_count++;
+                    e->seq = ++cache->seq_counter;
+                    evict_if_over_budget_locked(cache);
+                }
+            }
+            pthread_mutex_unlock(&cache->lock);
+            return;
+        }
+    }
+    pthread_mutex_unlock(&cache->lock);
+}
+
+/* ------------------------------------------------------------------ */
+/* Per-thread acquisition tracking                                     */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    metalbear_account_cache *cache;
+    metalbear_account_context *ctx;
+} acquired_ref;
+
+static _Thread_local acquired_ref *acq_buf = NULL;
+static _Thread_local size_t acq_len = 0;
+static _Thread_local size_t acq_cap = 0;
+
+/* Called by metalbear_account_cache_get on every successful acquisition so the
+ * request observer can release the reference at request end. Internal to this
+ * file; declared here so get() can call it. */
+void account_cache_push_acquired(metalbear_account_cache *cache,
+                                 metalbear_account_context *ctx) {
+    if (acq_len == acq_cap) {
+        size_t new_cap = acq_cap ? acq_cap * 2 : 8;
+        acquired_ref *grown = realloc(acq_buf, new_cap * sizeof(*grown));
+        if (!grown)
+            return; /* out of memory: skip tracking, the cache still
+                     * owns the context and will free it at cache_free
+                     * time. The reference simply stays pinned. */
+        acq_buf = grown;
+        acq_cap = new_cap;
+    }
+    acq_buf[acq_len].cache = cache;
+    acq_buf[acq_len].ctx = ctx;
+    acq_len++;
+}
+
+void metalbear_account_cache_release_thread_local(void) {
+    for (size_t i = 0; i < acq_len; i++)
+        metalbear_account_cache_release(acq_buf[i].cache, acq_buf[i].ctx);
+    acq_len = 0;
+}
+
+void metalbear_account_cache_stats(metalbear_account_cache *cache,
+                                   size_t *resident, size_t *idle,
+                                   uint64_t *evictions, uint64_t *hits,
+                                   uint64_t *misses) {
+    if (resident) *resident = 0;
+    if (idle) *idle = 0;
+    if (evictions)
+        *evictions =
+            atomic_load_explicit(&cache->evictions, memory_order_relaxed);
+    if (hits) *hits = atomic_load_explicit(&cache->hits, memory_order_relaxed);
+    if (misses)
+        *misses = atomic_load_explicit(&cache->misses, memory_order_relaxed);
+    if (!cache || (!resident && !idle)) return;
+    pthread_mutex_lock(&cache->lock);
+    if (resident) *resident = cache->total_count;
+    if (idle) *idle = cache->idle_count;
+    pthread_mutex_unlock(&cache->lock);
 }

--- a/src/ops/metrics.c
+++ b/src/ops/metrics.c
@@ -56,6 +56,15 @@ static const struct {
         {"dns_failures_total", "Handle DNS records that could not be written."},
     [METALBEAR_METRIC_CRAWL_FAILURES] =
         {"crawl_failures_total", "requestCrawl announcements that failed."},
+    [METALBEAR_METRIC_ACCOUNT_CACHE_HITS] =
+        {"account_cache_hits_total",
+         "Account contexts reused from the resident cache."},
+    [METALBEAR_METRIC_ACCOUNT_CACHE_MISSES] =
+        {"account_cache_misses_total",
+         "Account contexts opened because they were not resident."},
+    [METALBEAR_METRIC_ACCOUNT_CACHE_EVICTIONS] =
+        {"account_cache_evictions_total",
+         "Idle account contexts closed to stay under the resident budget."},
 };
 
 void metalbear_metrics_inc(metalbear_metric metric) {

--- a/src/ops/status.c
+++ b/src/ops/status.c
@@ -199,6 +199,27 @@ static wf_status metrics_handler(void *ctx, const wf_xrpc_request *req,
                        (unsigned long long)metalbear_metrics_get(i));
     }
 
+    /* Account cache residency, read from the cache at scrape time (a gauge, not
+     * a counter — the metrics model keeps current state out of the counter
+     * table). resident counts every open context; idle ones are evictable
+     * under the resident budget. */
+    {
+        size_t resident = 0, idle = 0;
+        metalbear_account_cache_stats(server->account_cache, &resident, &idle,
+                                      NULL, NULL, NULL);
+        ok = sb_append(
+            &sb,
+            "# HELP metalbear_account_cache_resident Open account contexts "
+            "(referenced or idle).\n"
+            "# TYPE metalbear_account_cache_resident gauge\n"
+            "metalbear_account_cache_resident %llu\n"
+            "# HELP metalbear_account_cache_idle Idle (fully released, "
+            "evictable) account contexts.\n"
+            "# TYPE metalbear_account_cache_idle gauge\n"
+            "metalbear_account_cache_idle %llu\n",
+            (unsigned long long)resident, (unsigned long long)idle);
+    }
+
     /*
      * Per-route series. The label is escaped because a route name reaches
      * here from the network — the AppView proxy forwards NSIDs this server

--- a/src/server.c
+++ b/src/server.c
@@ -437,6 +437,21 @@ metalbear_account_context *resolve_request_context(metalbear_server *server,
     return context_for_did(server, did);
 }
 
+/* XRPC request observer: fires once per request after the handler returns, on
+ * the worker thread that served it. Every account context resolved on the
+ * request path was acquired (refcounted) by metalbear_account_cache_get; drop
+ * them all here so the cache can evict idle accounts under its resident
+ * budget. Called for every request, so handlers never release by hand. */
+static void account_cache_request_observer(void *ctx, const char *nsid,
+                                           const char *path, const char *method,
+                                           unsigned int status) {
+    (void)nsid;
+    (void)path;
+    (void)method;
+    (void)status;
+    metalbear_account_cache_release_thread_local();
+}
+
 /* wolfram per-request resolver: map a request to the correct account's repo /
  * blob stores. Borrowed pointers remain valid for the request duration because
  * the cache outlives the request. */
@@ -2243,6 +2258,19 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
      * reads. */
     metalbear_account_cache_set_sequencer(server->account_cache,
                                           server->sequencer);
+    /* Bound the resident account set for small hosts (e.g. a 256 MB Pi 1B).
+     * Defaults conservatively; override with METALBEAR_MAX_RESIDENT_ACCOUNTS.
+     */
+    {
+        const char *max_res = getenv("METALBEAR_MAX_RESIDENT_ACCOUNTS");
+        if (max_res && max_res[0]) {
+            char *end = NULL;
+            long v = strtol(max_res, &end, 10);
+            if (end != max_res && v > 0)
+                metalbear_account_cache_set_max_resident(server->account_cache,
+                                                         (size_t)v);
+        }
+    }
     if (!server->account_cache) {
         LOG_ERROR("cannot create account cache");
         goto fail;
@@ -2267,6 +2295,12 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
                 if (acct->repo)
                     metalbear_sequencer_reconcile_repo(server->sequencer,
                                                        acct->repo);
+                /* This context was opened solely for reconciliation during
+                 * startup; release it so it becomes evictable under the
+                 * resident budget rather than pinned for the process lifetime.
+                 * Request-path acquisitions are released by the request
+                 * observer instead. */
+                metalbear_account_cache_release(server->account_cache, acct);
             }
             metalbear_account_entries_free(entries, count);
         }
@@ -2407,6 +2441,12 @@ metalbear_server *metalbear_server_start(const metalbear_config *config) {
     }
 
     wf_xrpc_server_set_auth_callback(server->xrpc, authenticate, server);
+
+    /* Release every account context acquired on the request path once the
+     * handler has returned, so the bounded cache can evict idle accounts.
+     * See account_cache_request_observer. */
+    wf_xrpc_server_set_request_observer(server->xrpc,
+                                        account_cache_request_observer, server);
 
     /* Register OAuth HTTP routes (bypass XRPC auth) */
     /* One OAuth store for the host. The account a token speaks for comes from

--- a/test/test_account_cache.c
+++ b/test/test_account_cache.c
@@ -1,0 +1,153 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "metalbear/account/account_cache.h"
+#include "metalbear/account/account_registry.h"
+#include "metalbear/account/account_context.h"
+#include "metalbear/sequencer.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NACCOUNTS 8
+
+static const char *DIDS[NACCOUNTS] = {
+    "did:plc:cachetest0001", "did:plc:cachetest0002", "did:plc:cachetest0003",
+    "did:plc:cachetest0004", "did:plc:cachetest0005", "did:plc:cachetest0006",
+    "did:plc:cachetest0007", "did:plc:cachetest0008",
+};
+static const char *HANDLES[NACCOUNTS] = {
+    "acc1.test", "acc2.test", "acc3.test", "acc4.test",
+    "acc5.test", "acc6.test", "acc7.test", "acc8.test",
+};
+
+static int failures;
+#define CHECK(expr)                                                            \
+    do {                                                                       \
+        if (!(expr)) {                                                         \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr);    \
+            failures++;                                                        \
+        }                                                                      \
+    } while (0)
+
+/* Touch every account once; with a tight resident budget the cache must evict
+ * idle contexts and never exceed the budget. */
+static void test_eviction(void) {
+    char tmpl[] = "/tmp/mb_cache_XXXXXX";
+    char *root = mkdtemp(tmpl);
+    CHECK(root != NULL);
+
+    metalbear_account_registry *registry = NULL;
+    char reg_path[256];
+    snprintf(reg_path, sizeof(reg_path), "%s/registry.sqlite3", root);
+    CHECK(metalbear_account_registry_open(reg_path, &registry) == WF_OK);
+
+    for (int i = 0; i < NACCOUNTS; i++) {
+        char dir[256];
+        snprintf(dir, sizeof(dir), "%s/acct%d", root, i);
+        mkdir(dir, 0700);
+        CHECK(metalbear_account_registry_add(registry, DIDS[i], HANDLES[i], "x",
+                                             dir) == WF_OK);
+    }
+
+    metalbear_account_cache *cache = metalbear_account_cache_new(
+        "did:plc:service", "https://example.com", root);
+    CHECK(cache != NULL);
+    metalbear_account_cache_set_max_resident(cache, 2);
+
+    for (int i = 0; i < NACCOUNTS; i++) {
+        metalbear_account_context *ctx =
+            metalbear_account_cache_get(cache, registry, DIDS[i]);
+        CHECK(ctx != NULL);
+        /* A second get of the same DID must return the cached (same) context
+         * and count a hit, not reopen. */
+        metalbear_account_context *again =
+            metalbear_account_cache_get(cache, registry, DIDS[i]);
+        CHECK(again == ctx);
+        metalbear_account_cache_release(cache, again);
+        metalbear_account_cache_release(cache, ctx);
+    }
+
+    size_t resident = 0, idle = 0;
+    uint64_t hits = 0, misses = 0, evictions = 0;
+    metalbear_account_cache_stats(cache, &resident, &idle, &evictions, &hits,
+                                  &misses);
+    /* Budget is 2 idle; after releasing everything, resident must be <= 2. */
+    CHECK(resident <= 2);
+    /* Eight distinct accounts, each fetched twice: 8 misses, 8 hits. */
+    CHECK(misses == NACCOUNTS);
+    CHECK(hits == NACCOUNTS);
+    /* At least some evictions must have occurred to stay under budget. */
+    CHECK(evictions > 0);
+    CHECK(idle == resident);
+
+    metalbear_account_cache_free(cache);
+    metalbear_account_registry_free(registry);
+}
+
+#define NTHREADS 4
+#define ITERS 200
+
+static metalbear_account_cache *g_cache;
+static metalbear_account_registry *g_registry;
+
+static void *hammer(void *arg) {
+    (void)arg;
+    for (int i = 0; i < ITERS; i++) {
+        int idx = rand() % NACCOUNTS;
+        metalbear_account_context *ctx =
+            metalbear_account_cache_get(g_cache, g_registry, DIDS[idx]);
+        if (ctx) metalbear_account_cache_release(g_cache, ctx);
+    }
+    return NULL;
+}
+
+static void test_concurrent(void) {
+    char tmpl[] = "/tmp/mb_cache_c_XXXXXX";
+    char *root = mkdtemp(tmpl);
+    CHECK(root != NULL);
+
+    char reg_path[256];
+    snprintf(reg_path, sizeof(reg_path), "%s/registry.sqlite3", root);
+    CHECK(metalbear_account_registry_open(reg_path, &g_registry) == WF_OK);
+    for (int i = 0; i < NACCOUNTS; i++) {
+        char dir[256];
+        snprintf(dir, sizeof(dir), "%s/acct%d", root, i);
+        mkdir(dir, 0700);
+        CHECK(metalbear_account_registry_add(g_registry, DIDS[i], HANDLES[i],
+                                             "x", dir) == WF_OK);
+    }
+
+    g_cache = metalbear_account_cache_new("did:plc:service",
+                                          "https://example.com", root);
+    CHECK(g_cache != NULL);
+    metalbear_account_cache_set_max_resident(g_cache, 4);
+
+    pthread_t threads[NTHREADS];
+    for (int i = 0; i < NTHREADS; i++)
+        pthread_create(&threads[i], NULL, hammer, NULL);
+    for (int i = 0; i < NTHREADS; i++) pthread_join(threads[i], NULL);
+
+    size_t resident = 0, idle = 0;
+    metalbear_account_cache_stats(g_cache, &resident, &idle, NULL, NULL, NULL);
+    /* Concurrency must not let resident exceed the budget plus the in-flight
+     * threads (each holds at most one referenced context). */
+    CHECK(resident <= 4 + NTHREADS);
+
+    metalbear_account_cache_free(g_cache);
+    metalbear_account_registry_free(g_registry);
+    g_cache = NULL;
+    g_registry = NULL;
+}
+
+int main(void) {
+    test_eviction();
+    test_concurrent();
+    if (failures) {
+        fprintf(stderr, "%d account-cache check(s) failed\n", failures);
+        return 1;
+    }
+    printf("all account-cache checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
Bound the account context cache (issue #33) so memory no longer grows with the number of accounts ever touched — required for the 256 MB Raspberry Pi 1B target.

- reference-counted cache entries (`get` acquires, `release` drops)
- idle (fully released) contexts evicted LRU once over `METALBEAR_MAX_RESIDENT_ACCOUNTS` (default 256)
- request-path acquisitions released automatically by a new XRPC request observer, so route handlers are unchanged
- startup reconciliation releases its contexts by hand
- residency gauges (`account_cache_resident`/`account_cache_idle`) + hit/miss/eviction counters in `/metrics`
- adds `test/test_account_cache.c` (eviction + concurrent lookup)

Closes #33.